### PR TITLE
Added Coal & Combustion emi mapping files

### DIFF
--- a/gch4i/sector_code/emi_mapping/coal_emis.py
+++ b/gch4i/sector_code/emi_mapping/coal_emis.py
@@ -4,7 +4,7 @@ Date Last Modified:     2024-07-02
 Authors Name:           A. Burnette (RTI International)
 Purpose:                Mapping of coal emissions to State, Year, emissions format
 Input Files:            - Coal_90-22_FRv1-InvDBcorrection.xlsx
-Output Files:           - TBD
+Output Files:           - Do not use output. This is a single function script.
 Notes:                  - This version of emi mapping is draft for mapping .py files
 """
 

--- a/gch4i/sector_code/emi_mapping/coal_emis.py
+++ b/gch4i/sector_code/emi_mapping/coal_emis.py
@@ -1,0 +1,98 @@
+"""
+Name:                   coal_emis.py
+Date Last Modified:     2024-07-02
+Authors Name:           A. Burnette (RTI International)
+Purpose:                Mapping of coal emissions to State, Year, emissions format
+Input Files:            - Coal_90-22_FRv1-InvDBcorrection.xlsx
+Output Files:           - TBD
+Notes:                  - This version of emi mapping is draft for mapping .py files
+"""
+
+# %% STEP 0. Load packages, configuration files, and local parameters ------------------
+import pandas as pd
+from gch4i.utils import tg_to_kt
+
+
+from gch4i.config import (
+    V3_DATA_PATH,
+    ghgi_data_dir_path,
+    max_year,
+    min_year,
+    tmp_data_dir_path,
+)
+
+
+# %% STEP 1. Create Emi Mapping Functions
+
+
+def get_underground_liberated_coal_inv_data(input_path, output_path):
+    """read in the ch4_kt values for each state"""
+
+    emi_df = (
+        # read in the data
+        pd.read_excel(
+            input_path,
+            sheet_name="InvDB",
+            skiprows=15,
+            nrows=514,
+            usecols="A:BA"
+        )
+        # name column names lower
+        .rename(columns=lambda x: str(x).lower())
+        # get just methane emissions
+        .query("(ghg == 'CH4') & (subcategory1.str.contains('Liberated'))")
+        # drop columns we don't need (Leave GeoRef, [Years])
+        .drop(
+            columns=[
+                "sector",
+                "category",
+                "subcategory1",
+                "subcategory2",
+                "subcategory3",
+                "subcategory4",
+                "subcategory5",
+                "carbon pool",
+                "fuel1",
+                "fuel2",
+                "exclude",
+                "id",
+                "sensitive (y or n)",
+                "data type",
+                "subsector",
+                "crt code",
+                "units",
+                "ghg",
+                "gwp"
+            ]
+        )
+        # set the index to state
+        .rename(columns={"georef": "state_code"})
+        .set_index("state_code")
+        # convert "NO" string to numeric (will become np.nan)
+        .apply(pd.to_numeric, errors="coerce")
+        # drop states that have all nan values
+        .dropna(how="all")
+        # reset the index state back to a column
+        .reset_index()
+        # make table long by state/year
+        .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")
+        .assign(ch4_kt=lambda df: df["ch4_tg"] * tg_to_kt)
+        .drop(columns=["ch4_tg"])
+        # correct column types
+        .astype({"year": int, "ch4_kt": float})
+        .fillna({"ch4_kt": 0})
+        # filter to required years
+        .query("year.between(@min_year, @max_year)")
+    )
+    emi_df.to_csv(output_path, index=False)
+
+
+# %% Input and Output File paths
+# INVENTORY INPUT FILE
+inventory_workbook_path = ghgi_data_dir_path / "coal/Coal_90-22_FRv1-InvDBcorrection.xlsx"
+
+# INVENTORY OUTPUT FILE
+output_path_liberated = V3_DATA_PATH / "emis/under_lib_emi.csv"
+
+# %% Use Function
+get_underground_liberated_coal_inv_data(inventory_workbook_path, output_path_liberated)

--- a/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
+++ b/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
@@ -1,10 +1,10 @@
 """
 Name:                   coal_emis.py
-Date Last Modified:     2024-07-02
+Date Last Modified:     2024-07-03
 Authors Name:           A. Burnette (RTI International)
 Purpose:                Mapping of coal emissions to State, Year, emissions format
 Input Files:            - Coal_90-22_FRv1-InvDBcorrection.xlsx
-Output Files:           - TBD
+Output Files:           - coal_post_surf_emi.csv, coal_post_under_emi.csv, coal_surf_emi.csv, coal_under_emi.csv
 Notes:                  - This version of emi mapping is draft for mapping .py files
 """
 

--- a/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
+++ b/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
@@ -1,0 +1,106 @@
+"""
+Name:                   coal_emis.py
+Date Last Modified:     2024-07-02
+Authors Name:           A. Burnette (RTI International)
+Purpose:                Mapping of coal emissions to State, Year, emissions format
+Input Files:            - Coal_90-22_FRv1-InvDBcorrection.xlsx
+Output Files:           - TBD
+Notes:                  - This version of emi mapping is draft for mapping .py files
+"""
+
+# %% STEP 0. Load packages, configuration files, and local parameters ------------------
+import pandas as pd
+
+from gch4i.config import (
+    V3_DATA_PATH,
+    ghgi_data_dir_path,
+    max_year,
+    min_year,
+    tmp_data_dir_path,
+)
+
+from gch4i.utils import tg_to_kt
+
+
+# %% STEP 1. Create Emi Mapping Functions
+def get_coal_inv_data(input_path, output_path, subcategory):
+    """read in the ch4_kt values for each state
+    User is required to specify the subcategory of interest:
+    - coal_post_surf
+    - coal_post_under
+    - coal_surf
+    - coal_under
+    """
+    subcategory_strings = {
+        "coal_post_surf": "Post-Mining (Surface)",
+        "coal_post_under": "Post-Mining (Underground)",
+        "coal_surf": "Surface Mining",
+        "coal_under": "Liberated"
+    }
+    subcategory_string = subcategory_strings.get(subcategory)
+    if subcategory_string is None:
+        raise ValueError("Invalid subcategory. Please choose from coal_post_surf, coal_post_under, coal_surf, coal_under.")
+    emi_df = (
+        # read in the data
+        pd.read_excel(
+            input_path,
+            sheet_name="InvDB",
+            skiprows=15,
+            nrows=514,
+            usecols="A:BA"
+        )
+        # name column names lower
+        .rename(columns=lambda x: str(x).lower())
+        # modify subcategory1 column
+        .replace({"subcategory1": {"Underground Recovered & Used": "Underground Liberated"}})
+        # get just methane emissions for the specified subcategory
+        .query("(ghg == 'CH4') & (subcategory1.str.contains(@subcategory_string, regex=False))")
+        # keep only columns that have georef or a year
+        .filter(regex='georef|19|20')
+        # set the index to state
+        .rename(columns={"georef": "state_code"})
+        .set_index("state_code")
+        # convert "NO" string to numeric (will become np.nan)
+        .apply(pd.to_numeric, errors="coerce")
+        # drop states that have all nan values
+        .dropna(how="all")
+        # reset the index state back to a column
+        .reset_index()
+        # make table long by state/year
+        .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")
+        .assign(ch4_kt=lambda df: df["ch4_tg"] * tg_to_kt)
+        .drop(columns=["ch4_tg"])
+        # correct column types
+        .astype({"year": int, "ch4_kt": float})
+        .fillna({"ch4_kt": 0})
+        # filter to required years
+        .query("year.between(@min_year, @max_year)")
+    )
+    emi_df.to_csv(output_path, index=False)
+
+
+# %% STEP 2. Set Input/Output Paths
+
+# INPUT PATHS
+inventory_workbook_path = ghgi_data_dir_path / "coal/Coal_90-22_FRv1-InvDBcorrection.xlsx"
+
+
+# OUTPUT PATHS
+output_path_coal_post_surf = V3_DATA_PATH / "emis/coal_post_surf_emi.csv"
+output_path_coal_post_under = V3_DATA_PATH / "emis/coal_post_under_emi.csv"
+output_path_coal_surf = V3_DATA_PATH / "emis/coal_surf_emi.csv"
+output_path_coal_under = V3_DATA_PATH / "emis/coal_under_emi.csv"
+
+# %% STEP 3. Function Calls
+
+# Post-Mining (Surface)
+get_coal_inv_data(inventory_workbook_path, output_path_coal_post_surf, "coal_post_surf")
+
+# Post-Mining (Underground)
+get_coal_inv_data(inventory_workbook_path, output_path_coal_post_under, "coal_post_under")
+
+# Surface Mining
+get_coal_inv_data(inventory_workbook_path, output_path_coal_surf, "coal_surf")
+
+# Liberated | Recovered & Used
+get_coal_inv_data(inventory_workbook_path, output_path_coal_under, "coal_under")

--- a/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
+++ b/gch4i/sector_code/emi_mapping/coal_emis_inclusive.py
@@ -1,16 +1,16 @@
+
 """
-Name:                   coal_emis.py
+Name:                   coal_emis_inclusive.py
 Date Last Modified:     2024-07-03
 Authors Name:           A. Burnette (RTI International)
 Purpose:                Mapping of coal emissions to State, Year, emissions format
 Input Files:            - Coal_90-22_FRv1-InvDBcorrection.xlsx
-Output Files:           - coal_post_surf_emi.csv, coal_post_under_emi.csv, coal_surf_emi.csv, coal_under_emi.csv
+Output Files:           - coal_post_surf_emi.csv, coal_post_under_emi.csv,
+                        coal_surf_emi.csv, coal_under_emi.csv
 Notes:                  - This version of emi mapping is draft for mapping .py files
 """
-
 # %% STEP 0. Load packages, configuration files, and local parameters ------------------
 import pandas as pd
-
 from gch4i.config import (
     V3_DATA_PATH,
     ghgi_data_dir_path,
@@ -18,11 +18,11 @@ from gch4i.config import (
     min_year,
     tmp_data_dir_path,
 )
-
 from gch4i.utils import tg_to_kt
 
-
 # %% STEP 1. Create Emi Mapping Functions
+
+
 def get_coal_inv_data(input_path, output_path, subcategory):
     """read in the ch4_kt values for each state
     User is required to specify the subcategory of interest:
@@ -39,7 +39,8 @@ def get_coal_inv_data(input_path, output_path, subcategory):
     }
     subcategory_string = subcategory_strings.get(subcategory)
     if subcategory_string is None:
-        raise ValueError("Invalid subcategory. Please choose from coal_post_surf, coal_post_under, coal_surf, coal_under.")
+        raise ValueError("""Invalid subcategory. Please choose from coal_post_surf,
+                        coal_post_under, coal_surf, coal_under.""")
     emi_df = (
         # read in the data
         pd.read_excel(
@@ -78,29 +79,38 @@ def get_coal_inv_data(input_path, output_path, subcategory):
     )
     emi_df.to_csv(output_path, index=False)
 
-
 # %% STEP 2. Set Input/Output Paths
 
 # INPUT PATHS
 inventory_workbook_path = ghgi_data_dir_path / "coal/Coal_90-22_FRv1-InvDBcorrection.xlsx"
-
 
 # OUTPUT PATHS
 output_path_coal_post_surf = V3_DATA_PATH / "emis/coal_post_surf_emi.csv"
 output_path_coal_post_under = V3_DATA_PATH / "emis/coal_post_under_emi.csv"
 output_path_coal_surf = V3_DATA_PATH / "emis/coal_surf_emi.csv"
 output_path_coal_under = V3_DATA_PATH / "emis/coal_under_emi.csv"
-
 # %% STEP 3. Function Calls
-
 # Post-Mining (Surface)
-get_coal_inv_data(inventory_workbook_path, output_path_coal_post_surf, "coal_post_surf")
-
+get_coal_inv_data(
+    inventory_workbook_path,
+    output_path_coal_post_surf,
+    "coal_post_surf"
+    )
 # Post-Mining (Underground)
-get_coal_inv_data(inventory_workbook_path, output_path_coal_post_under, "coal_post_under")
-
+get_coal_inv_data(
+    inventory_workbook_path,
+    output_path_coal_post_under,
+    "coal_post_under"
+    )
 # Surface Mining
-get_coal_inv_data(inventory_workbook_path, output_path_coal_surf, "coal_surf")
-
+get_coal_inv_data(
+    inventory_workbook_path,
+    output_path_coal_surf,
+    "coal_surf"
+    )
 # Liberated | Recovered & Used
-get_coal_inv_data(inventory_workbook_path, output_path_coal_under, "coal_under")
+get_coal_inv_data(
+    inventory_workbook_path,
+    output_path_coal_under,
+    "coal_under"
+    )

--- a/gch4i/sector_code/emi_mapping/comb_mobile_emis.py
+++ b/gch4i/sector_code/emi_mapping/comb_mobile_emis.py
@@ -1,0 +1,228 @@
+
+"""
+Name:                   comb_mobile_emis.py
+Date Last Modified:     2024-07-10
+Authors Name:           A. Burnette (RTI International)
+Purpose:                Mapping of combustion - mobile emissions to State, Year,
+                        emissions format
+Input Files:            - SIT Mobile Dataframe 5.24.2023.xlsx
+Output Files:           - Emissions by State, Year for each subcategory
+Notes:                  - This version of emi mapping is draft for mapping .py files
+"""
+# %% STEP 0. Load packages, configuration files, and local parameters ------------------
+import pandas as pd
+from gch4i.config import (
+    V3_DATA_PATH,
+    ghgi_data_dir_path,
+    max_year,
+    min_year,
+    tmp_data_dir_path,
+)
+from gch4i.utils import tg_to_kt  # Determine if this conversion rate is correct
+
+
+# %% STEP 1. Create Emi Mapping Functions
+def get_comb_mobile_inv_data(input_path, output_path, subcategory):
+    """read in the ch4_kt values for each state
+    User is required to specify the subcategory of interest:
+    - comb_mob_aircraft_emi
+    - comb_mob_alt_fuel_emi
+    - comb_mob_buses_emi
+    - comb_mob_con_equip_emi
+    - comb_mob_diesel_emi"
+    - comb_mob_farm_equip_emi
+    - comb_mob_ldt_emi
+    - comb_mob_loco_emi
+    - comb_mob_mcycle_emi
+    - comb_mob_other_emi
+    - comb_mob_pass_emi
+    - comb_mob_vehicles_emi
+    - comb_mob_waterways_emi
+    - comb_mob_non_hwy_emi
+    - comb_mob_gas_hwy_emi
+    """
+    subcategory_strings = {
+        "comb_mob_aircraft_emi": "Aircraft",
+        "comb_mob_alt_fuel_emi": "Alternative Fuel Vehicles$",
+        "comb_mob_buses_emi": "Buses",
+        "comb_mob_con_equip_emi": "Construction Equipment",
+        "comb_mob_diesel_emi": "Diesel Highway$",
+        "comb_mob_farm_equip_emi": "Farm Equipment",
+        "comb_mob_ldt_emi": "Light-Duty Trucks",
+        "comb_mob_loco_emi": "Locomotives",
+        "comb_mob_mcycle_emi": "Motorcycles",
+        "comb_mob_other_emi": "Other",
+        "comb_mob_pass_emi": "Passenger Cars",
+        "comb_mob_vehicles_emi": "Vehicles",
+        "comb_mob_waterways_emi": "Boats",
+        "comb_mob_non_hwy_emi": "Non-Highway$",
+        "comb_mob_gas_hwy_emi": "Gasoline Highway$"
+        }
+    subcategory_string = subcategory_strings.get(
+        subcategory
+    )
+    if subcategory_string is None:
+        raise ValueError("""Invalid arg. Please use one of the following arguments:
+                comb_mob_aircraft_emi, comb_mob_alt_fuel_emi, comb_mob_con_equip_emi,
+                comb_mob_diesel_emi, comb_mob_farm_equip_emi, comb_mob_ldt_emi.,
+                comb_mob_loco_emi, comb_mob_mcycle_emi, comb_mob_other_emi,
+                comb_mob_pass_emi, comb_mob_waterways_emi, comb_mob_non_hwy_emi,
+                comb_mob_gas_hwy_emi""")
+    emi_df = (
+        # read in the data
+        pd.read_excel(
+            input_path,
+            sheet_name="Table",
+            nrows=3112,
+            usecols="A:AI",
+            index_col=None
+        )
+    )
+    emi_df2 = (emi_df.rename(columns=lambda x: str(x).lower())
+        .drop(columns=["state"])
+        .rename(columns={'unnamed: 0': 'state_code'})
+        # Remove CO2 from sector and get emissions for specific subcategory
+        .query('sector.str.contains("CH4") == True' and f'sector.str.contains("{subcategory_string}", regex={"False" if subcategory_string in ["comb_mob_alt_fuel_emi", "comb_mob_diesel_emi", "comb_mob_non_hwy_emi", "comb_mob_gas_hwy_emi"] else "True"})', engine='python')
+        # change sector inputs to unified subcategory
+        .drop(columns=["sector"])
+        # Drop rows with 0 across all years
+        .replace(0, pd.NA)
+        .dropna(subset=emi_df.columns[emi_df.columns.get_loc('1990'):], how='all')
+        .fillna(0)
+        # reset the index state back to a column
+        .reset_index(drop=True)
+        # make table long by state/year
+        .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")
+        .assign(ch4_kt=lambda df: df["ch4_tg"] * tg_to_kt)
+        .drop(columns=["ch4_tg"])
+        # correct column types
+        .astype({"year": int, "ch4_kt": float})
+        .fillna({"ch4_kt": 0})
+        # group by state and year and sum the ch4_tg column
+        .groupby(["state_code", "year"]).sum().reset_index()
+        # filter to required years
+        .query("year.between(@min_year, @max_year)")
+        .sort_values("year")
+    )
+    emi_df2.to_csv(output_path, index=False)
+    # return emi_df2
+
+# %% STEP 2. Set Input/Output Paths
+# INPUT PATHS
+inventory_workbook_path = ghgi_data_dir_path / "SIT Mobile Dataframe 5.24.2023.xlsx"
+# outpath = tmp_data_dir_path / "comb_mobile_emis_test.csv"
+
+# OUTPUT PATHS
+output_path_comb_mob_aircraft_emi = V3_DATA_PATH / "emis/comb_mob_aircraft_emi.csv"
+output_path_comb_mob_alt_fuel_emi = V3_DATA_PATH / "emis/comb_mob_alt_fuel_emi.csv"
+output_path_comb_mob_buses_emi = V3_DATA_PATH / "emis/comb_mob_buses_emi.csv"
+output_path_comb_mob_con_equip_emi = V3_DATA_PATH / "emis/comb_mob_con_equip_emi.csv"
+output_path_comb_mob_diesel_emi = V3_DATA_PATH / "emis/comb_mob_diesel_emi.csv"
+output_path_comb_mob_farm_equip_emi = V3_DATA_PATH / "emis/comb_mob_farm_equip_emi.csv"
+output_path_comb_mob_ldt_emi = V3_DATA_PATH / "emis/comb_mob_ldt_emi.csv"
+output_path_comb_mob_loco_emi = V3_DATA_PATH / "emis/comb_mob_loco_emi.csv"
+output_path_comb_mob_mcycle_emi = V3_DATA_PATH / "emis/comb_mob_mcycle_emi.csv"
+output_path_comb_mob_other_emi = V3_DATA_PATH / "emis/comb_mob_other_emi.csv"
+output_path_comb_mob_pass_emi = V3_DATA_PATH / "emis/comb_mob_pass_emi.csv"
+output_path_comb_mob_vehicles_emi = V3_DATA_PATH / "emis/comb_mob_vehicles_emi.csv"
+output_path_comb_mob_waterways_emi = V3_DATA_PATH / "emis/comb_mob_waterways_emi.csv"
+output_path_comb_mob_non_hwy_emi = V3_DATA_PATH / "emis/comb_mob_non_hwy_emi.csv"
+output_path_comb_mob_gas_hwy_emi = V3_DATA_PATH / "emis/comb_mob_gas_hwy_emi.csv"
+
+# %% STEP 3. Function Calls
+# Aircraft
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_aircraft_emi,
+    "comb_mob_aircraft_emi"
+)
+# Alternative Fuel Vehicles
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_alt_fuel_emi,
+    "comb_mob_alt_fuel_emi"
+    )
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_buses_emi,
+    "comb_mob_buses_emi"
+    )
+# Construction Equipment
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_con_equip_emi,
+    "comb_mob_con_equip_emi"
+    )
+# Diesel Highway
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_diesel_emi,
+    "comb_mob_diesel_emi"
+    )
+# Farm Equipment
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_farm_equip_emi,
+    "comb_mob_farm_equip_emi"
+    )
+# Light-Duty Trucks
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_ldt_emi,
+    "comb_mob_ldt_emi"
+    )
+# Locomotives
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_loco_emi,
+    "comb_mob_loco_emi"
+    )
+# Motorcycles
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_mcycle_emi,
+    "comb_mob_mcycle_emi"
+    )
+# Other
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_other_emi,
+    "comb_mob_other_emi"
+    )
+# Passenger Cars
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_pass_emi,
+    "comb_mob_pass_emi"
+    )
+# Vehicles
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_vehicles_emi,
+    "comb_mob_vehicles_emi"
+    )
+# Waterways
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_waterways_emi,
+    "comb_mob_waterways_emi"
+    )
+# Non-Highway
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_non_hwy_emi,
+    "comb_mob_non_hwy_emi"
+    )
+# Gasoline Highway
+get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_gas_hwy_emi,
+    "comb_mob_gas_hwy_emi"
+    )
+
+# %% STEP TEST. Test Function Calls
+testing = get_comb_mobile_inv_data(
+    inventory_workbook_path,
+    output_path_comb_mob_vehicles_emi,
+    "comb_mob_vehicles_emi"
+    )

--- a/gch4i/sector_code/emi_mapping/comb_stationary_emis.py
+++ b/gch4i/sector_code/emi_mapping/comb_stationary_emis.py
@@ -1,0 +1,249 @@
+
+"""
+Name:                   comb_stationary_emis.py
+Date Last Modified:     2024-07-10
+Authors Name:           A. Burnette (RTI International)
+Purpose:                Mapping of combustion - stationary emissions to State, Year,
+                        emissions format
+Input Files:            - Stationary Calcs 90-22_3_12_24_FR.xlsx
+Output Files:           - TBD
+Notes:                  - This version of emi mapping is draft for mapping .py files
+"""
+# %% STEP 0. Load packages, configuration files, and local parameters ------------------
+import pandas as pd
+from gch4i.config import (
+    V3_DATA_PATH,
+    ghgi_data_dir_path,
+    max_year,
+    min_year,
+    tmp_data_dir_path,
+)
+from gch4i.utils import tg_to_kt  # Determine if this conversion rate is correct
+
+
+# %% STEP 1. Create Emi Mapping Functions
+def get_comb_stat_inv_data(input_path, output_path, subcategory):
+    """read in the ch4_kt values for each state
+    User is required to specify the subcategory of interest:
+    - comb_stat_coal_elec_emi
+    - comb_stat_coal_indu_emi
+    - comb_stat_coal_comm_emi
+    - comb_stat_coal_resi_emi
+    - comb_stat_coal_nomap_emi
+    - comb_stat_oil_elec_emi
+    - comb_stat_oil_indu_emi
+    - comb_stat_oil_comm_emi
+    - comb_stat_oil_resi_emi
+    - comb_stat_oil_nomap_emi
+    - comb_stat_gas_elec_emi
+    - comb_stat_gas_indu_emi
+    - comb_stat_gas_comm_emi
+    - comb_stat_gas_resi_emi
+    - comb_stat_gas_nomap_emi
+    - comb_stat_wood_elec_emi
+    - comb_stat_wood_indu_emi
+    - comb_stat_wood_comm_emi
+    - comb_stat_wood_resi_emi
+    - comb_stat_wood_nomap_emi
+    """
+    subcategory_strings = {
+        "comb_stat_coal_elec_emi": ["Electricity Generation", "Coal"],
+        "comb_stat_coal_indu_emi": ["Industrial", "Coal"],
+        "comb_stat_coal_comm_emi": ["Commercial", "Coal"],
+        "comb_stat_coal_resi_emi": ["Residential", "Coal"],
+        "comb_stat_coal_nomap_emi": ["US Territories", "Coal"],
+        "comb_stat_oil_elec_emi": ["Electricity Generation", "Petroleum"],
+        "comb_stat_oil_indu_emi": ["Industrial", "Petroleum"],
+        "comb_stat_oil_comm_emi": ["Commercial", "Petroleum"],
+        "comb_stat_oil_resi_emi": ["Residential", "Petroleum"],
+        "comb_stat_oil_nomap_emi": ["US Territories", "Petroleum"],
+        "comb_stat_gas_elec_emi": ["Electricity Generation", "Natural Gas"],
+        "comb_stat_gas_indu_emi": ["Industrial", "Natural Gas"],
+        "comb_stat_gas_comm_emi": ["Commercial", "Natural Gas"],
+        "comb_stat_gas_resi_emi": ["Residential", "Natural Gas"],
+        "comb_stat_gas_nomap_emi": ["US Territories", "Natural Gas"],
+        "comb_stat_wood_elec_emi": ["Electricity Generation", "Biomass"],
+        "comb_stat_wood_indu_emi": ["Industrial", "Biomass"],
+        "comb_stat_wood_comm_emi": ["Commercial", "Biomass"],
+        "comb_stat_wood_resi_emi": ["Residential", "Biomass"],
+        "comb_stat_wood_nomap_emi": ["US Territories", "Biomass"]
+        }
+    subcategory_string = subcategory_strings.get(subcategory)
+    if subcategory_string is None:
+        raise ValueError("""Invalid arg. Please choose from the following arguments:
+            comb_stat_coal_elec_emi, comb_stat_coal_indu_emi, comb_stat_coal_comm_emi,
+            comb_stat_coal_resi_emi, comb_stat_coal_nomap_emi, comb_stat_oil_elec_emi,
+            comb_stat_oil_indu_emi, comb_stat_oil_comm_emi, comb_stat_oil_resi_emi,
+            comb_stat_oil_nomap_emi, comb_stat_gas_elec_emi, comb_stat_gas_indu_emi,
+            comb_stat_gas_comm_emi, comb_stat_gas_resi_emi, comb_stat_gas_nomap_emi,
+            comb_stat_wood_elec_emi, comb_stat_wood_indu_emi, comb_stat_wood_comm_emi,
+            comb_stat_wood_resi_emi, comb_stat_wood_nomap_emi""")
+    emi_df = (
+        # read in the data
+        pd.read_excel(
+            input_path,
+            sheet_name="InvDB",
+            skiprows=15,
+            nrows=41,
+            usecols="A:BA",
+            index_col=None
+        )
+        # name column names lower
+        .rename(columns=lambda x: str(x).lower())
+        # create state_code column
+        .rename(columns={'georef': 'state_code'})
+        # set state code as index
+        .set_index("state_code")
+        # query to filter ghg == CH4 & category & fuel1
+        .query('(ghg == "CH4") & (category == @subcategory_string[0]) & (fuel1 == @subcategory_string[1])')
+        # filter columns
+        .filter(regex='state_code|19|20')
+        # convert "NO" and "NE" string to numeric (will become np.nan)
+        .apply(pd.to_numeric, errors="coerce")
+        # drop states that have all nan values
+        .dropna(how="all")
+        # make table long by state/year
+        .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")
+        .assign(ch4_kt=lambda df: df["ch4_tg"] * tg_to_kt)
+        .drop(columns=["ch4_tg"])
+        # correct column types
+        .astype({"year": int, "ch4_kt": float})
+        .fillna({"ch4_kt": 0})
+        # filter to required years
+        .query("year.between(@min_year, @max_year)")
+    )
+    # emi_df.to_csv(output_path, index=False)
+    return emi_df
+
+# %% STEP 2. Set Input/Output Paths
+
+
+# INPUT PATHS
+inventory_workbook_path = ghgi_data_dir_path / "Stationary Calcs 90-22_3_12_24_FR.xlsx"
+
+# OUTPUT PATHS
+output_path_comb_stat_coal_elec_emi = V3_DATA_PATH / "emis/comb_stat_coal_elec_emi.csv"
+output_path_comb_stat_coal_indu_emi = V3_DATA_PATH / "emis/comb_stat_coal_indu_emi.csv"
+output_path_comb_stat_coal_comm_emi = V3_DATA_PATH / "emis/comb_stat_coal_comm_emi.csv"
+output_path_comb_stat_coal_resi_emi = V3_DATA_PATH / "emis/comb_stat_coal_resi_emi.csv"
+output_path_comb_stat_coal_nomap_emi = V3_DATA_PATH / "emis/comb_stat_coal_nomap_emi.csv"
+output_path_comb_stat_oil_elec_emi = V3_DATA_PATH / "emis/comb_stat_oil_elec_emi.csv"
+output_path_comb_stat_oil_indu_emi = V3_DATA_PATH / "emis/comb_stat_oil_indu_emi.csv"
+output_path_comb_stat_oil_comm_emi = V3_DATA_PATH / "emis/comb_stat_oil_comm_emi.csv"
+output_path_comb_stat_oil_resi_emi = V3_DATA_PATH / "emis/comb_stat_oil_resi_emi.csv"
+output_path_comb_stat_oil_nomap_emi = V3_DATA_PATH / "emis/comb_stat_oil_nomap_emi.csv"
+output_path_comb_stat_gas_elec_emi = V3_DATA_PATH / "emis/comb_stat_gas_elec_emi.csv"
+output_path_comb_stat_gas_indu_emi = V3_DATA_PATH / "emis/comb_stat_gas_indu_emi.csv"
+output_path_comb_stat_gas_comm_emi = V3_DATA_PATH / "emis/comb_stat_gas_comm_emi.csv"
+output_path_comb_stat_gas_resi_emi = V3_DATA_PATH / "emis/comb_stat_gas_resi_emi.csv"
+output_path_comb_stat_gas_nomap_emi = V3_DATA_PATH / "emis/comb_stat_gas_nomap_emi.csv"
+output_path_comb_stat_wood_elec_emi = V3_DATA_PATH / "emis/comb_stat_wood_elec_emi.csv"
+output_path_comb_stat_wood_indu_emi = V3_DATA_PATH / "emis/comb_stat_wood_indu_emi.csv"
+output_path_comb_stat_wood_comm_emi = V3_DATA_PATH / "emis/comb_stat_wood_comm_emi.csv"
+output_path_comb_stat_wood_resi_emi = V3_DATA_PATH / "emis/comb_stat_wood_resi_emi.csv"
+output_path_comb_stat_wood_nomap_emi = V3_DATA_PATH / "emis/comb_stat_wood_nomap_emi.csv"
+
+# %% STEP 3. Function Calls
+# Coal
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_coal_elec_emi,
+    "comb_stat_coal_elec_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_coal_indu_emi,
+    "comb_stat_coal_indu_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_coal_comm_emi,
+    "comb_stat_coal_comm_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_coal_resi_emi,
+    "comb_stat_coal_resi_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_coal_nomap_emi,
+    "comb_stat_coal_nomap_emi"
+    )
+# Oil
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_oil_elec_emi,
+    "comb_stat_oil_elec_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_oil_indu_emi,
+    "comb_stat_oil_indu_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_oil_comm_emi,
+    "comb_stat_oil_comm_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_oil_resi_emi,
+    "comb_stat_oil_resi_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_oil_nomap_emi,
+    "comb_stat_oil_nomap_emi"
+    )
+# Gas
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_gas_elec_emi,
+    "comb_stat_gas_elec_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_gas_indu_emi,
+    "comb_stat_gas_indu_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_gas_comm_emi,
+    "comb_stat_gas_comm_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_gas_resi_emi,
+    "comb_stat_gas_resi_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_gas_nomap_emi,
+    "comb_stat_gas_nomap_emi"
+    )
+# Wood
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_wood_elec_emi,
+    "comb_stat_wood_elec_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_wood_indu_emi,
+    "comb_stat_wood_indu_emi")
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_wood_comm_emi,
+    "comb_stat_wood_comm_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_wood_resi_emi,
+    "comb_stat_wood_resi_emi"
+    )
+get_comb_stat_inv_data(
+    inventory_workbook_path,
+    output_path_comb_stat_wood_nomap_emi,
+    "comb_stat_wood_nomap_emi"
+    )

--- a/gch4i/sector_code/emi_mapping/test_coal_emis_inclusive.py
+++ b/gch4i/sector_code/emi_mapping/test_coal_emis_inclusive.py
@@ -1,0 +1,53 @@
+
+import unittest
+import coal_emis_inclusive
+import os
+from coal_emis_inclusive import inventory_workbook_path
+
+
+class Testget_coal_inv_data(unittest.TestCase):
+    def setUp(self):
+        self.input_file = inventory_workbook_path
+        self.output_file_coal_post_surf = "test_coal_post_surf_emi.csv"
+        self.output_file_coal_post_under = "test_coal_post_under_emi.csv"
+        self.output_file_coal_surf = "test_coal_surf_emi.csv"
+        self.output_file_coal_under = "test_coal_under_emi.csv"
+
+    def tearDown(self) -> None:
+        try:
+            os.remove(self.output_file_coal_post_surf)
+            os.remove(self.output_file_coal_post_under)
+            os.remove(self.output_file_coal_surf)
+            os.remove(self.output_file_coal_under)
+        except FileNotFoundError:
+            pass
+
+    def test_get_coal_inv_data(self):
+        coal_emis_inclusive.get_coal_inv_data(
+            self.input_file,
+            self.output_file_coal_post_surf,
+            "coal_post_surf"
+        )
+        self.assertTrue(os.path.exists(self.output_file_coal_post_surf))
+        coal_emis_inclusive.get_coal_inv_data(
+            self.input_file,
+            self.output_file_coal_post_under,
+            "coal_post_under"
+        )
+        self.assertTrue(os.path.exists(self.output_file_coal_post_under))
+        coal_emis_inclusive.get_coal_inv_data(
+            self.input_file,
+            self.output_file_coal_surf,
+            "coal_surf"
+        )
+        self.assertTrue(os.path.exists(self.output_file_coal_surf))
+        coal_emis_inclusive.get_coal_inv_data(
+            self.input_file,
+            self.output_file_coal_under,
+            "coal_under"
+        )
+        self.assertTrue(os.path.exists(self.output_file_coal_under))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gch4i/sector_code/emi_mapping/test_comb_mobile_emis.py
+++ b/gch4i/sector_code/emi_mapping/test_comb_mobile_emis.py
@@ -1,0 +1,61 @@
+
+import unittest
+import comb_mobile_emis
+import os
+from comb_mobile_emis import inventory_workbook_path
+
+
+class Testget_comb_mobile_inv_data(unittest.TestCase):
+    def setUp(self):
+        self.input_file = inventory_workbook_path
+        self.output_file_comb_mob_ldt_emi = "test_comb_mob_ldt_emi.csv"
+        self.output_file_comb_mob_loco_emi = "test_comb_mob_loco_emi.csv"
+        self.output_file_comb_mob_mcycle_emi = "test_comb_mob_mcycle_emi.csv"
+        self.output_file_comb_mob_other_emi = "test_comb_mob_other_emi.csv"
+        self.output_file_comb_mob_pass_emi = "test_comb_mob_pass_emi.csv"
+
+    def tearDown(self) -> None:
+        try:
+            os.remove(self.output_file_comb_mob_ldt_emi)
+            os.remove(self.output_file_comb_mob_loco_emi)
+            os.remove(self.output_file_comb_mob_mcycle_emi)
+            os.remove(self.output_file_comb_mob_other_emi)
+            os.remove(self.output_file_comb_mob_pass_emi)
+        except FileNotFoundError:
+            pass
+
+    def test_get_comb_mobile_inv_data(self):
+        comb_mobile_emis.get_comb_mobile_inv_data(
+            self.input_file,
+            self.output_file_comb_mob_ldt_emi,
+            "comb_mob_ldt_emi"
+        )
+        self.assertTrue(os.path.exists(self.output_file_comb_mob_ldt_emi))
+        comb_mobile_emis.get_comb_mobile_inv_data(
+            self.input_file,
+            self.output_file_comb_mob_loco_emi,
+            "comb_mob_loco_emi"
+        )
+        self.assertTrue(os.path.exists(self.output_file_comb_mob_loco_emi))
+        comb_mobile_emis.get_comb_mobile_inv_data(
+            self.input_file,
+            self.output_file_comb_mob_mcycle_emi,
+            "comb_mob_mcycle_emi"
+        )
+        self.assertTrue(os.path.exists(self.output_file_comb_mob_mcycle_emi))
+        comb_mobile_emis.get_comb_mobile_inv_data(
+            self.input_file,
+            self.output_file_comb_mob_other_emi,
+            "comb_mob_other_emi"
+        )
+        self.assertTrue(os.path.exists(self.output_file_comb_mob_other_emi))
+        comb_mobile_emis.get_comb_mobile_inv_data(
+            self.input_file,
+            self.output_file_comb_mob_pass_emi,
+            "comb_mob_pass_emi"
+        )
+        self.assertTrue(os.path.exists(self.output_file_comb_mob_pass_emi))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**coal_emis_inclusive.py:** function maps coal emissions. Forces subcategory argument and raises error with list of acceptable subcategory arguments
**comb_mobile_emis:** function maps mobile combustion emissions. May need to remove categorical emissions that sum/total subcategories. Forces subcategory argument.
**comb_stationary_emis:** This is a draft function for stationary combustion emissions. We do not have state-level data yet, so function is built off of Stationary Calls 90-22_3_23_24_FR.xlsx.
**Other code:** Test code for emissions .py files.