### PR TITLE
Updates from failed QC; post_code_review branch crashed

### DIFF
--- a/gch4i/emis_processing/task_field_burning_emi.py
+++ b/gch4i/emis_processing/task_field_burning_emi.py
@@ -6,7 +6,7 @@ Purpose:               Clean and standardized field burning emissions data
 Input Files:           - gch4i_data_guide_v3.xlsx
                        - {V3_DATA_PATH}/ghgi/3F4_fbar/FBAR_90-22_State.xlsx.
 Output Files:          - {emi_data_dir_path}/barley_emi.csv
-                                            /chickpease_emi.csv
+                                            /chickpeas_emi.csv
                                             /cotton_emi.csv
                                             /drybeans_emi.csv
                                             /grasshay_emi.csv
@@ -15,7 +15,7 @@ Output Files:          - {emi_data_dir_path}/barley_emi.csv
                                             /maize_emi.csv
                                             /oats_emi.csv
                                             /other_grains_emi.csv
-                                            /peanutes_emi.csv
+                                            /peanuts_emi.csv
                                             /peas_emi.csv
                                             /potatoes_emi.csv
                                             /rice_emi.csv
@@ -42,7 +42,7 @@ from gch4i.config import (
     emi_data_dir_path,
     ghgi_data_dir_path,
     max_year,
-    min_year,
+    min_year
 )
 from gch4i.utils import tg_to_kt
 
@@ -136,11 +136,11 @@ for _id, _kwargs in emi_parameters_dict.items():
             )
             .rename(columns={"georef": "state_code"})
             .set_index("state_code")
-            # covert "NO" string to numeric (will become np.nan)
+            # Replace NA values with 0
+            .replace(0, pd.NA)
             .apply(pd.to_numeric, errors="coerce")
-            # drop states that have all nan values
             .dropna(how="all")
-            # reset the index state back to a column
+            .fillna(0)
             .reset_index()
             # make the table long by state/year
             .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")

--- a/gch4i/emis_processing/task_iron_steel_emi.py
+++ b/gch4i/emis_processing/task_iron_steel_emi.py
@@ -1,91 +1,81 @@
 """
 Name:                   task_iron_steel_emi.py
-Date Last Modified:     2024-12-12
-Authors Name:           C. COxen
+Date Last Modified:     2025-02-13
+Authors Name:           Chris Coxen
 Purpose:                Mapping of iron and steel emissions to State, Year, emissions
                         format
 gch4i_name:             2C1_iron_and_steel
-Input Files:            - 2C1_iron_and_steel/State_Iron-Steel_1990-2022.xlsx
-Output Files:           - iron_steel_emi.csv
-Notes:
+Input Files:            - {ghgi_data_dir_path}/2C1_iron_and_steel/
+                            State_Iron-Steel_1990-2022.xlsx
+Output Files:           - {emi_data_dir_path}/
+                            iron_steel_emi.csv
 """
 
+# %% STEP 0. Load packages, configuration files, and local parameters ------------------
 from pathlib import Path
 from typing import Annotated
 
 import pandas as pd
 from pytask import Product, mark, task
 
-from gch4i.config import (  # noqa
+from gch4i.config import (
+    V3_DATA_PATH,
     emi_data_dir_path,
     ghgi_data_dir_path,
+    min_year,
+    max_year
 )
 from gch4i.utils import tg_to_kt
 
 
-@mark.persist
-@task(id="iron_steel_emi")
-def task_get_iron_and_steel_inv_data(
-    input_path: Path = (
-        ghgi_data_dir_path / "2C1_iron_and_steel/State_Iron-Steel_1990-2022.xlsx"
-    ),
-    output_path: Annotated[Path, Product] = emi_data_dir_path / "iron_steel_emi.csv",
-) -> None:
+# %% Step 1. Create Function
+
+
+def get_iron_and_steel_inv_data(in_path, src):
+    """read in the ch4_kt values for each state
+
+    Function reads in the inventory data for iron and steel and returns the
+    emissions in kt for each state and year.
+
+    Parameters
+    ----------
+    in_path : str
+        path to the input file
+    src : str
+        subcategory of interest
+
+    Returns
+        Saves the emissions data to the output path.
     """
-    Read in the iron and steel data from the GHGI
-    """
+
+    # Read in the data
+    emi_df = pd.read_excel(
+        in_path,
+        sheet_name="InvDB",
+        skiprows=15,
+        nrows=457,
+        usecols="A:BA"
+        )
+    # Specify years to keep
+    year_list = [str(x) for x in list(range(min_year, max_year + 1))]
+    # Clean and format the data
     emi_df = (
-        # read in the data
-        pd.read_excel(
-            input_path,
-            sheet_name="InvDB",
-            skiprows=15,
-            nrows=457,
-            usecols="A:BA",
-        )
         # name column names lower
-        # drop columns we don't need
-        .drop(
-            columns=[
-                "Data Type",
-                "Sector",
-                "Subsector",
-                "Category",
-                # "Subcategory1",
-                "Subcategory2",
-                "Subcategory3",
-                "Subcategory4",
-                "Subcategory5",
-                "Carbon Pool",
-                "Fuel1",
-                "Fuel2",
-                # "GeoRef",
-                "Exclude",
-                "CRT Code",
-                "ID",
-                "Sensitive (Y or N)",
-                "Units",
-                # "GHG",
-                "GWP",
-            ]
-        )
-        # filter on Sinter because it's the only emission type with CH4 emission values
-        .query("Subcategory1 == 'Sinter Production'")
-        .drop(columns="Subcategory1")
-        .rename(columns=lambda x: str(x).lower())
-        # get just methane emissions
-        .query("ghg == 'CH4'")
-        # remove that column
-        .drop(columns="ghg")
-        # set the index to state
+        emi_df.rename(columns=lambda x: str(x).lower())
+        # Rename state column
         .rename(columns={"georef": "state_code"})
+        # Filter out national data
         .query("state_code != 'National'")
+        # Filter for Sinter Production & CH4
+        .query("(subcategory1 == 'Sinter Production') & (ghg == 'CH4')")
+        # Filter for state_code and years
+        .filter(items=["state_code"] + year_list, axis=1)
         .set_index("state_code")
-        # covert "NO" string to numeric (will become np.nan)
+        # Replace NA values with 0
+        .replace(0, pd.NA)
         .apply(pd.to_numeric, errors="coerce")
-        # drop states that have all nan values
         .dropna(how="all")
-        # reset the index state back to a column
+        .fillna(0)
         .reset_index()
         # make the table long by state/year
         .melt(id_vars="state_code", var_name="year", value_name="ch4_tg")
@@ -96,5 +86,73 @@ def task_get_iron_and_steel_inv_data(
         .fillna({"ghgi_ch4_kt": 0})
         # get only the years we need
         .query("year.between(@min_year, @max_year)")
-    )
-    emi_df.to_csv(output_path, index=False)
+        # Ensure state/year grouping is unique
+        .groupby(["state_code", "year"])["ghgi_ch4_kt"]
+        .sum()
+        .reset_index()
+        )
+    return emi_df
+
+
+# %% STEP 2. Initialize Parameters
+"""
+This section initializes the parameters for the task and stores them in the
+emi_parameters_dict.
+
+The parameters are read from the emi_proxy_mapping sheet of the gch4i_data_guide_v3.xlsx
+file. The parameters are used to create the pytask task for the emi.
+"""
+# gch4i_name in gch4i_data_guide_v3.xlsx, emi_proxy_mapping sheet
+source_name = "2C1_iron_and_steel"
+# Directory name for GHGI data
+source_path = "2C1_iron_and_steel"
+
+# Data Guide Directory
+proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+# Read and query for the source name (ghch4i_name)
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+    f"gch4i_name == '{source_name}'"
+)
+
+# Initialize the emi_parameters_dict
+emi_parameters_dict = {}
+# Loop through the proxy data and store the parameters in the emi_parameters_dict
+for emi_name, data in proxy_data.groupby("emi_id"):
+    emi_parameters_dict[emi_name] = {
+        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "source_list": [x.strip().casefold() for x in data.Category.to_list()],
+        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+    }
+
+emi_parameters_dict
+
+
+# %% STEP 3. Create Pytask Function and Loop
+
+for _id, _kwargs in emi_parameters_dict.items():
+
+    @mark.persist
+    @task(id=_id, kwargs=_kwargs)
+    def task_iron_steel_emi(
+        input_paths: list[Path],
+        source_list: list[str],
+        output_path: Annotated[Path, Product],
+    ) -> None:
+
+        # Initialize the emi_df_list
+        emi_df_list = []
+        # Loop through the input paths and source list to get the emissions data
+        for input_path, ghgi_group in zip(input_paths, source_list):
+            individual_emi_df = get_iron_and_steel_inv_data(input_path,
+                                                            ghgi_group)
+            emi_df_list.append(individual_emi_df)
+
+        # Concatenate the emissions data and group by state and year
+        emission_group_df = (
+            pd.concat(emi_df_list)
+            .groupby(["state_code", "year"])["ghgi_ch4_kt"]
+            .sum()
+            .reset_index()
+        )
+        # Save the emissions data to the output path
+        emission_group_df.to_csv(output_path)

--- a/gch4i/emis_processing/task_natural_gas_emis.py
+++ b/gch4i/emis_processing/task_natural_gas_emis.py
@@ -24,7 +24,7 @@ from gch4i.config import (
     emi_data_dir_path,
     ghgi_data_dir_path,
     max_year,
-    min_year,
+    min_year
 )
 from gch4i.utils import tg_to_kt
 
@@ -180,6 +180,10 @@ def read_allwell_data(in_path, sheet_name, src):
         .sum()
         .reset_index()
     )
+    # Remove state_code for federal_gom_offshore_emi
+    if src == "Federal Offshore":
+        emi_df = emi_df.drop(columns="state_code")
+
     emi_df.head()
     return emi_df
 
@@ -255,7 +259,6 @@ for _id, _kwargs in emi_parameters_dict.items():
             "basin_395_emi",
             "basin_430_emi",
             "basin_other_emi",
-            "federal_gom_offshore_emi",
             "gas_well_drilled_emi",
             "gb_stations_emi",
             "non_assoc_conv_emi",
@@ -295,6 +298,13 @@ for _id, _kwargs in emi_parameters_dict.items():
         ]:
             read_function = None
             groupers = ["state_code", "year"]
+
+        elif emi_name in [
+            "federal_gom_offshore_emi"
+        ]:
+            read_function = read_allwell_data
+            groupers = ["year"]
+
         else:
             return ValueError(f"{emi_name} not ready.")
 

--- a/gch4i/emis_processing/task_petro_production_emi.py
+++ b/gch4i/emis_processing/task_petro_production_emi.py
@@ -53,7 +53,6 @@ import ast
 
 from gch4i.config import (
     V3_DATA_PATH,
-    tmp_data_dir_path,
     emi_data_dir_path,
     ghgi_data_dir_path,
     max_year,
@@ -264,20 +263,20 @@ def get_petro_production_inv_data(in_path, src, params):
     if src in ["offshore gom federal waters",
                "offshore pacific federal and state waters",
                "offshore alaska state waters"]:
-        # If True, 'make_up' list for queryign emission_source
+        # If True, 'make_up' list for querying emission_source
         if src == "offshore alaska state waters":
             make_up = ["Offshore Alaska State Waters, Vent/Leak",
                        "Offshore Alaska State Waters, Flare"]
-        # If True, 'make_up' list for queryign emission_source
+        # If True, 'make_up' list for querying emission_source
         elif src == "offshore pacific federal and state waters":
             make_up = ["Offshore Pacific Federal and State Waters, Flare",
                        "Offshore Pacific Federal and State Waters, Vent/Leak"]
-        # If True, 'make_up' list for queryign emission_source
+        # If True, 'make_up' list for querying emission_source
         elif src == "offshore gom federal waters":
             make_up = ["Offshore GoM Federal Waters: Major Complexes",
                        "Offshore GoM Federal Waters: Minor Complexes",
                        "Offshore GoM Federal Waters: Flaring"]
-            state_name = "ALL"  # I assume GOM (Gulf of Mexico)
+            # state_name = "ALL"  # I assume GOM (Gulf of Mexico)
         emi_df = (
             # Rename columns
             emi_df.rename(columns=lambda x: str(x).lower())
@@ -297,15 +296,15 @@ def get_petro_production_inv_data(in_path, src, params):
             emi_df.melt(id_vars="emission_source", var_name="year", value_name="ch4_mt")
             # Convert mt to kt
             .assign(ghgi_ch4_kt=lambda x: x["ch4_mt"] / 1000)
-            .drop(columns=["ch4_mt"])
+            .drop(columns=["ch4_mt"])  # dropped state_code
             .astype({"year": int, "ghgi_ch4_kt": float})
             .fillna({"ghgi_ch4_kt": 0})
             # Ensure only years between min_year and max_year are included
             .query("year.between(@min_year, @max_year)")
             # Make state_code "ALL"
-            .assign(state_code="ALL")
+            # .assign(state_code="ALL")
             # Ensure state/year grouping is unique
-            .groupby(["state_code", "year"])["ghgi_ch4_kt"]
+            .groupby(["year"])["ghgi_ch4_kt"]  # removed state_code
             .sum()
             .reset_index()
         )
@@ -401,7 +400,7 @@ for emi_name, data in proxy_data.groupby("emi_id"):
         "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory2.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": tmp_data_dir_path / f"{emi_name}.csv"
+        "output_path": emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict
@@ -430,11 +429,25 @@ for _id, _kwargs in emi_parameters_dict.items():
             emi_df_list.append(individual_emi_df)
 
         # Concatenate the emissions data and group by state and year
-        emission_group_df = (
-            pd.concat(emi_df_list)
-            .groupby(["state_code", "year"])["ghgi_ch4_kt"]
-            .sum()
-            .reset_index()
+        df = (
+            pd.concat(emi_df_list).reset_index(drop=True)
         )
+        group_cols = [col for col in df.columns if col != "ghgi_ch4_kt"]
+        emission_group_df = df.groupby(group_cols)["ghgi_ch4_kt"].sum().reset_index()
+
+        # if 'state_code' in individual_emi_df.columns:
+        #     emission_group_df = (
+        #         pd.concat(emi_df_list)
+        #         .groupby(["year"])["ghgi_ch4_kt"]
+        #         .sum()
+        #         .reset_index()
+        #     )
+        # else:
+        #     emission_group_df = (
+        #         pd.concat(emi_df_list)
+        #         .groupby(["state_code", "year"])["ghgi_ch4_kt"]
+        #         .sum()
+        #         .reset_index()
+        #     )
         # Save the emissions data to the output path
         emission_group_df.to_csv(output_path)

--- a/gch4i/proxy_processing/task_farm_pipelines_proxy.py
+++ b/gch4i/proxy_processing/task_farm_pipelines_proxy.py
@@ -2,14 +2,19 @@
 Name:                   task_farm_pipelines_proxy.py
 Date Last Modified:     2025-02-07
 Authors Name:           John Bollenbacher (RTI International)
-Purpose:                This file builds spatial proxies for natural gas pipelines on farmlands. 
-                        Reads pipeline geometries, Finds spatial intersection of pipelines and cropland for each year, 
-                        and saves out a table of the resulting farm pipeline geometries for each year and state.
-Input Files:            - {sector_data_dir_path}/enverus/midstream/Rextag_Natural_Gas.gdb
-                        - {sector_data_dir_path}/nass_cdl/{year}_30m_cdls_all_crop_binary.tif
-                        - {V3_DATA_PATH}/geospatial/cb_2018_us_state_500k/cb_2018_us_state_500k.shp
+Purpose:                This file builds spatial proxies for natural gas pipelines on
+                        farmlands.
+                        Reads pipeline geometries, Finds spatial intersection of
+                        pipelines and cropland for each year, and saves out a table of
+                        the resulting farm pipeline geometries for each year and state.
+Input Files:            - {sector_data_dir_path}/enverus/midstream/
+                            Rextag_Natural_Gas.gdb
+                        - {sector_data_dir_path}/nass_cdl/
+                            {year}_30m_cdls_all_crop_binary.tif
+                        - {global_data_dir_path}/tl_2020_us_state.zip
 Output Files:           - farm_pipelines_proxy.parquet
 """
+# %% Import Libraries
 from pathlib import Path
 from typing import Annotated
 
@@ -24,44 +29,51 @@ from shapely.geometry import shape
 from gch4i.config import (
     max_year,
     min_year,
+    global_data_dir_path,
     proxy_data_dir_path,
-    sector_data_dir_path,
-    V3_DATA_PATH
+    sector_data_dir_path
 )
-
-lower_48_and_DC = ('AL', 'AR', 'AZ', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'IA', 'ID', 'IL', 
-            'IN', 'KS', 'KY', 'LA', 'MA', 'MD', 'ME', 'MI', 'MN', 'MO', 'MS', 'MT',
-            'NC', 'ND', 'NE', 'NH', 'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA',
-            'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VA', 'VT', 'WA', 'WI', 'WV', 'WY', 'DC')
 
 verbose = False
 
+
+# %% Pytask Function
 @mark.persist
 @task(id="farm_pipeline_proxy")
 def get_farm_pipeline_proxy_data(
-    #Inputs
-    enverus_midstream_pipelines_path: Path = sector_data_dir_path / "enverus/midstream/Rextag_Natural_Gas.gdb",
-    croplands_path_template: Path = sector_data_dir_path / "nass_cdl/{year}_30m_cdls_all_crop_binary.tif",
-    state_shapes_path: Path = V3_DATA_PATH / 'geospatial/cb_2018_us_state_500k/cb_2018_us_state_500k.shp')
-
-    #Outputs
-    output_path: Annotated[Path, Product] = proxy_data_dir_path / "farm_pipelines_proxy.parquet"
+    # Inputs
+    state_path: Path = global_data_dir_path / "tl_2020_us_state.zip",
+    # Outputs
+    output_path: Annotated[Path, Product] = proxy_data_dir_path /
+        "farm_pipelines_proxy.parquet"
 ):
-    
+
     ###############################################################
     # Load and prepare pipeline data
     ###############################################################
 
-    if verbose: print('loading state and pipeline data')
-    
-    # Load state geometries and pipeline data (keeping existing code)
-    state_shapes = gpd.read_file(state_shapes_path)
-    state_shapes = state_shapes.rename(columns={'STUSPS': 'state_code'})[['state_code', 'geometry']]
-    state_shapes = state_shapes[state_shapes['state_code'].isin(lower_48_and_DC)]
-    state_shapes = state_shapes.to_crs(epsg=4326)
+    # Input path cannnot be in function because it is a directory, not a file
+    croplands_path_template: Path = sector_data_dir_path / "nass_cdl/{year}_30m_cdls_all_crop_binary.tif"
+    enverus_midstream_pipelines_path: Path = sector_data_dir_path / "enverus/midstream/Rextag_Natural_Gas.gdb"
+
+    if verbose:
+        print('loading state and pipeline data')
+
+    # Load state shapes
+    state_shapes = (
+        gpd.read_file(state_path)
+        .rename(columns={"STUSPS": "state_code"})
+        .astype({"STATEFP": int})
+        # get only lower 48 + DC
+        .query("(STATEFP < 60) & (STATEFP != 2) & (STATEFP != 15)")
+        .loc[:, ["state_code", "geometry"]]
+        .to_crs(epsg=4326)
+    )
 
     # Load and filter pipeline data
-    enverus_pipelines_gdf = gpd.read_file(enverus_midstream_pipelines_path, layer='NaturalGasPipelines')
+    enverus_pipelines_gdf = gpd.read_file(
+        enverus_midstream_pipelines_path,
+        layer='NaturalGasPipelines')
     enverus_pipelines_gdf = enverus_pipelines_gdf.to_crs(epsg=4326)
     enverus_pipelines_gdf = enverus_pipelines_gdf[
         (enverus_pipelines_gdf['STATUS'] == 'Operational') &
@@ -80,38 +92,43 @@ def get_farm_pipeline_proxy_data(
         # Load cropland data and find raster intersection
         ###############################################################
 
-        if verbose: print('  loading cropland raster data')    
+        if verbose:
+            print('  loading cropland raster data')
         with rasterio.open(croplands_path) as src:
             # Read cropland data
             cropland_mask = src.read(1) > 0
             transform = src.transform
             raster_crs = src.crs
 
-            #reproject pipelines to raster's CRS for raster operations
+            # Reproject pipelines to raster's CRS for raster operations
             year_pipelines_gdf_raster_crs = year_pipelines_gdf.to_crs(raster_crs).copy()
-                
+
             # Rasterize pipelines to same grid as cropland
-            if verbose: print('  rasterizing pipelines')
-            pipeline_shapes = ((geom, 1) for geom in year_pipelines_gdf_raster_crs.geometry)
+            if verbose:
+                print('  rasterizing pipelines')
+            pipeline_shapes = (
+                (geom, 1) for geom in year_pipelines_gdf_raster_crs.geometry)
             pipeline_raster = rasterize(
-                pipeline_shapes, 
+                pipeline_shapes,
                 out_shape=cropland_mask.shape,
                 transform=transform,
                 dtype=np.uint8
             )
 
             # Find intersection areas
-            if verbose: print('  finding cropland-pipelines intersection')
+            if verbose:
+                print('  finding cropland-pipelines intersection')
             intersection_mask = (cropland_mask & (pipeline_raster > 0))
-            
+
         ###############################################################
         # Find vector intersection using raster intersection
         ###############################################################
 
             # Vectorize only the intersection areas
-            if verbose: print('  vectorizing cropland raster bins which intersect pipeline bins')
+            if verbose:
+                print(' vectorizing cropland raster bins which intersect pipeline bins')
             intersection_shapes = shapes(
-                intersection_mask.astype(np.uint8), 
+                intersection_mask.astype(np.uint8),
                 transform=transform,
                 connectivity=4,
                 mask=intersection_mask
@@ -120,17 +137,19 @@ def get_farm_pipeline_proxy_data(
                 {"geometry": shape(geom), "properties": {"value": val}}
                 for geom, val in intersection_shapes if val == 1
             ]
-        
+
             # Convert intersection shapes to GeoDataFrame
-            if verbose: print('  put intersecting cropland geometries into gdf')
+            if verbose:
+                print('  put intersecting cropland geometries into gdf')
             if intersection_geometries:
                 intersection_gdf = gpd.GeoDataFrame.from_features(
                     intersection_geometries,
                     crs=raster_crs
                 ).to_crs(epsg=4326)
-                
+
                 # Intersect with original pipelines to maintain pipeline attributes
-                if verbose: print('  computing vector overlay between cropland and pipelines')
+                if verbose:
+                    print('  computing vector overlay between cropland and pipelines')
                 year_pipelines_gdf = gpd.overlay(
                     year_pipelines_gdf,
                     intersection_gdf,
@@ -139,10 +158,15 @@ def get_farm_pipeline_proxy_data(
                 )
 
                 # Recombine each pipeline into single geometry
-                if verbose: print('  recombining split pipeline geometries')
+                if verbose:
+                    print('  recombining split pipeline geometries')
                 year_pipelines_gdf = year_pipelines_gdf.dissolve(
-                    by=['LOC_ID', 'DIAMETER'], #if rows match on all these columns, then combine their geometries into a single geometry in one row
-                    aggfunc='first' #for other columns besides geometry and the matched columns, use the first row's values. there are no other columns, though.
+                    # if rows match on all these columns, then combine their geometries
+                    # into a single geometry in one row
+                    by=['LOC_ID', 'DIAMETER'],
+                    # for other columns besides geometry and the matched columns, use
+                    # the first row's values. there are no other columns, though.
+                    aggfunc='first'
                 ).reset_index()
 
             else:
@@ -157,13 +181,14 @@ def get_farm_pipeline_proxy_data(
         # Split by state and create vector proxy gdf
         ###############################################################
 
-        if verbose: print('  splitting by state')
-        
+        if verbose:
+            print('  splitting by state')
+
         # Split pipelines at state boundaries
         enverus_pipelines_gdf_split_by_state = gpd.overlay(
-            year_pipelines_gdf, 
+            year_pipelines_gdf,
             state_shapes,
-            how='intersection', 
+            how='intersection',
             keep_geom_type=True
         )
 
@@ -174,21 +199,27 @@ def get_farm_pipeline_proxy_data(
         # Calculate pipeline lengths and normalize rel_emi
         ###############################################################
 
-        if verbose: print('  computing pipeline lengths and final proxy gdf')
-        
+        if verbose:
+            print('  computing pipeline lengths and final proxy gdf')
+
         # Calculate pipeline lengths
         proxy_gdf = proxy_gdf.to_crs("ESRI:102003")
         proxy_gdf['rel_emi'] = proxy_gdf.geometry.length
         proxy_gdf = proxy_gdf.to_crs(epsg=4326)
 
         # Normalize relative emissions to sum to 1 for each year and state
-        proxy_gdf = proxy_gdf.groupby(['state_code', 'year']).filter(lambda x: x['rel_emi'].sum() > 0) #drop state-years with 0 total volume
-        proxy_gdf['rel_emi'] = proxy_gdf.groupby(['year', 'state_code'])['rel_emi'].transform(lambda x: x / x.sum() if x.sum() > 0 else 0) #normalize to sum to 1
-        sums = proxy_gdf.groupby(["state_code", "year"])["rel_emi"].sum() #get sums to check normalization
-        assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}" # assert that the sums are close to 1
+        # Drop years with zero volume
+        proxy_gdf = proxy_gdf.groupby(['year']).filter(lambda x: x['rel_emi'].sum() > 0)
+        # normalize to sum to 1
+        proxy_gdf['rel_emi'] = (
+            proxy_gdf.groupby(['year'])['rel_emi']
+            .transform(lambda x: x / x.sum() if x.sum() > 0 else 0))
+        # get sums to check normalization
+        sums = proxy_gdf.groupby(["year"])["rel_emi"].sum()
+        # assert that the sums are close to 1
+        assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
 
         return proxy_gdf
-    
 
     ###############################################################
     # Process each year, aggregate, and save
@@ -196,18 +227,24 @@ def get_farm_pipeline_proxy_data(
 
     year_proxy_gdfs = []
     for year in range(min_year, max_year+1):
-        if verbose: print(f'Processing year {year}')
+        if verbose:
+            print(f'Processing year {year}')
         croplands_path = croplands_path_template.parent / croplands_path_template.name.format(year=year)
         year_proxy_gdf = process_year(year, enverus_pipelines_gdf, croplands_path, state_shapes)
         year_proxy_gdfs.append(year_proxy_gdf)
-    
-    # Double check normalization
-    sums = proxy_gdf.groupby(["state_code", "year"])["rel_emi"].sum() #get sums to check normalization
-    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}" # assert that the sums are close to 1
 
     # Combine all years into single dataframe
     proxy_gdf = pd.concat(year_proxy_gdfs, ignore_index=True)
-    
+
+    # Double check normalization
+    # get sums to check normalization
+    sums = proxy_gdf.groupby(["year"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Drop state_code column
+    proxy_gdf = proxy_gdf.drop(columns=['state_code'])
+
     # Save to parquet
     proxy_gdf.to_parquet(output_path)
 
@@ -215,6 +252,5 @@ def get_farm_pipeline_proxy_data(
 # df = get_farm_pipeline_proxy_data()
 # df.info()
 # df
-
 
 # %%

--- a/gch4i/proxy_processing/task_ng_transmission_export_proxy.py
+++ b/gch4i/proxy_processing/task_ng_transmission_export_proxy.py
@@ -98,12 +98,15 @@ def get_ng_export_proxy_data(
         )
     # normalize to sum to 1
     proxy_gdf['rel_emi'] = (
-        proxy_gdf.groupby(['year', 'state_code'])['rel_emi']
+        proxy_gdf.groupby(['year'])['rel_emi']
         .transform(lambda x: x / x.sum() if x.sum() > 0 else 0))
     # get sums to check normalization
-    sums = proxy_gdf.groupby(["state_code", "year"])["rel_emi"].sum()
+    sums = proxy_gdf.groupby(["year"])["rel_emi"].sum()
     # assert that the sums are close to 1
     assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Drop state_code column
+    proxy_gdf = proxy_gdf.drop(columns=["state_code"])
 
     # Save to parquet
     proxy_gdf.to_parquet(output_path)

--- a/gch4i/proxy_processing/task_ng_transmission_import_proxy.py
+++ b/gch4i/proxy_processing/task_ng_transmission_import_proxy.py
@@ -93,17 +93,20 @@ def get_ng_import_proxy_data(
     # Normalize relative emissions to sum to 1 for each year and state
     # drop state-years with 0 total volume
     proxy_gdf = (
-        proxy_gdf.groupby(['state_code', 'year'])
+        proxy_gdf.groupby(['year'])
         .filter(lambda x: x['rel_emi'].sum() > 0)
         )
     # normalize to sum to 1
     proxy_gdf['rel_emi'] = (
-        proxy_gdf.groupby(['year', 'state_code'])['rel_emi']
+        proxy_gdf.groupby(['year'])['rel_emi']
         .transform(lambda x: x / x.sum() if x.sum() > 0 else 0))
     # get sums to check normalization
-    sums = proxy_gdf.groupby(["state_code", "year"])["rel_emi"].sum()
+    sums = proxy_gdf.groupby(["year"])["rel_emi"].sum()
     # assert that the sums are close to 1
     assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Drop state_code column
+    proxy_gdf = proxy_gdf.drop(columns=['state_code'])
 
     # Save to parquet
     proxy_gdf.to_parquet(output_path)

--- a/gch4i/proxy_processing/task_stat_comb_proxy.py
+++ b/gch4i/proxy_processing/task_stat_comb_proxy.py
@@ -1,19 +1,30 @@
 """
 Name:                   task_stat_comb_proxy.py
-Date Last Modified:     2024-10-31
-Authors Name:           A. Burnette (RTI International)
+Date Last Modified:     2025-02-19
+Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of stationary combustion proxy emissions
-Input Files:            -
-Output Files:           - elec_coal_proxy.parquet, elec_gas_proxy.parquet,
-                        elec_oil_proxy.parquet, elec_wood_proxy.parquet,
-                        indu_proxy.parquet
-Notes:                  -
+Input Files:            - Acid Rain Program Facilities: {GEPA_Stat_Path}/
+                            InputData/ARP_Data/EPA_ARP_2012-2022_Facility_Info.csv
+                        - Acid Rain Program Data: {GEPA_Stat_Path}/
+                            InputData/ARP_Data/EPA_ARP_2012-2022.csv
+                        - GHGRP Subpart C Emissions: {GEPA_Stat_Path}/
+                            InputData/GHGRP/GHGRP_SubpartCEmissions_2010-2023.csv
+                        - GHGRP Subpart D Emissions: {GEPA_Stat_Path}/
+                            InputData/GHGRP/GHGRP_SubpartDEmissions_2010-2023.csv
+                        - GHGRP Subpart D Facility Locations: {GEPA_Stat_Path}/
+                            InputData/GHGRP/GHGRP_FacilityInfo_2010-2023.csv
+Output Files:           - {proxy_data_dir_path}/
+                            elec_coal_proxy.parquet
+                            elec_gas_proxy.parquet
+                            elec_oil_proxy.parquet
+                            elec_wood_proxy.parquet
+                            indu_proxy.parquet
 """
 ########################################################################################
 # %% STEP 0.1. Load Packages
 
 from pathlib import Path
-import os
+# import os
 from typing import Annotated
 from pytask import Product, mark, task
 
@@ -23,41 +34,22 @@ import numpy as np
 import geopandas as gpd
 
 from gch4i.config import (
-    V3_DATA_PATH,
     proxy_data_dir_path,
+    sector_data_dir_path,
     max_year,
-    min_year,
-    years
+    min_year
 )
-
-########################################################################################
-# %% Load Path Files
-
-# Pathways
-GEPA_Stat_Path = V3_DATA_PATH.parent / "GEPA_Source_Code" / "GEPA_Combustion_Stationary"
-Global_Func_Path = V3_DATA_PATH.parent / "Global_Functions" / "Global_Functions"
-
-# Activity Data
-EPA_ARP_facilities = GEPA_Stat_Path / "InputData" / "ARP_Data" / "EPA_ARP_2012-2022_Facility_Info.csv"
-EPA_ARP_inputfile = GEPA_Stat_Path / "InputData/ARP_Data/EPA_ARP_2012-2022.csv"
-
-#NEI_resi_wood_inputfile = GEPA_Stat_Path / "InputData/NEII 2020 RWC Throughputs.xlsx"
-
-# GHGRP Data (reporting format changed in 2015)
-GHGRP_subC_inputfile = GEPA_Stat_Path / "InputData/GHGRP/GHGRP_SubpartCEmissions_2010-2023.csv" #subpart C facility IDs and emissions (locations not available)
-GHGRP_subD_inputfile = GEPA_Stat_Path / "InputData/GHGRP/GHGRP_SubpartDEmissions_2010-2023.csv" #subpart D facility IDs and emissions 
-GHGRP_subDfacility_loc_inputfile = GEPA_Stat_Path / "InputData/GHGRP/GHGRP_FacilityInfo_2010-2023.csv" #subpart D facility info (for all years, with ID & lat and lons)
-
 
 ########################################################################################
 # %% elec_coal_proxy
 
+
 @mark.persist
 @task(id='elec_coal_proxy')
 def task_get_reporting_electric_coal_proxy_data(
-    facility_path=EPA_ARP_facilities,
-    input_path=EPA_ARP_inputfile,
-    reporting_electric_coal_proxy_output_path: Annotated[Path, Product] = proxy_data_dir_path 
+    facility_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022_Facility_Info.csv",
+    input_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022.csv",
+    reporting_elec_coal_path_output_path: Annotated[Path, Product] = proxy_data_dir_path
     / 'elec_coal_proxy.parquet'
 ):
     """
@@ -68,12 +60,17 @@ def task_get_reporting_electric_coal_proxy_data(
     # Read in ARP Facility Data
     ARP_Facility = (
         pd.read_csv(facility_path, index_col=False)
-        .filter(items=['Facility ID', 'Facility Name', 'State', 'Latitude', 'Longitude'])
+        .filter(items=[
+            'Facility ID',
+            'Facility Name',
+            'State',
+            'Latitude',
+            'Longitude'])
         .drop_duplicates(['Facility ID', 'Latitude', 'Longitude'], keep='last')
         .rename(columns={'Facility ID': 'facility_id'})
         .reset_index(drop=True)
     )
-
+    # Convert to gdf
     ARP_Facility_gdf = (
         gpd.GeoDataFrame(
             ARP_Facility,
@@ -88,8 +85,9 @@ def task_get_reporting_electric_coal_proxy_data(
     # Read in Raw ARP Data & Clean Fuel Type
     ARP_Raw = (
         pd.read_csv(input_path, index_col=False)
-        .filter(items=['State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
-                       'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
+        .filter(items=[
+            'State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
+            'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
         .query('State not in ["VI", "MP", "GU", "AS", "PR", "AK", "HI"]')
     )
 
@@ -97,11 +95,16 @@ def task_get_reporting_electric_coal_proxy_data(
         ARP_Raw.assign(
             unit_clean=np.select(
                 [
-                    ARP_Raw['Unit Type'].str.contains('combustion turbine', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('combined cycle', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('wet bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('dry bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('bubbling', case=False, na=False)
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combustion turbine', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combined cycle', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'wet bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'dry bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'bubbling', case=False, na=False)
                 ],
                 [
                     'combustion turbine',
@@ -114,30 +117,34 @@ def task_get_reporting_electric_coal_proxy_data(
             ),
             fuel_clean=np.select(
                 [
-                    ARP_Raw['Primary Fuel Type'].isin(['Pipeline Natural Gas',
-                                                       'Natural Gas',
-                                                       'Other Gas',
-                                                       'Other Gas, Pipeline Natural Gas',
-                                                       'Natural Gas, Pipeline Natural Gas',
-                                                       'Process Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Petroleum Coke',
-                                                       'Coal',
-                                                       'Coal, Pipeline Natural Gas',
-                                                       'Coal, Natural Gas',
-                                                       'Coal, Wood',
-                                                       'Coal, Coal Refuse',
-                                                       'Coal Refuse',
-                                                       'Coal, Process Gas',
-                                                       'Coal, Diesel Oil',
-                                                       'Other Solid Fuel']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Other Oil',
-                                                       'Diesel Oil',
-                                                       'Diesel Oil, Residual Oil',
-                                                       'Diesel Oil, Pipeline Natural Gas',
-                                                       'Residual Oil',
-                                                       'Residual Oil, Pipeline Natural Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Wood',
-                                                       'Other Solid Fuel, Wood'])
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Pipeline Natural Gas',
+                        'Natural Gas',
+                        'Other Gas',
+                        'Other Gas, Pipeline Natural Gas',
+                        'Natural Gas, Pipeline Natural Gas',
+                        'Process Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Petroleum Coke',
+                        'Coal',
+                        'Coal, Pipeline Natural Gas',
+                        'Coal, Natural Gas',
+                        'Coal, Wood',
+                        'Coal, Coal Refuse',
+                        'Coal Refuse',
+                        'Coal, Process Gas',
+                        'Coal, Diesel Oil',
+                        'Other Solid Fuel']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Other Oil',
+                        'Diesel Oil',
+                        'Diesel Oil, Residual Oil',
+                        'Diesel Oil, Pipeline Natural Gas',
+                        'Residual Oil',
+                        'Residual Oil, Pipeline Natural Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Wood',
+                        'Other Solid Fuel, Wood'])
                 ],
                 [
                     'Gas',
@@ -152,7 +159,10 @@ def task_get_reporting_electric_coal_proxy_data(
     )
 
     # Coerce Heat Input (mmBtu)
-    ARP_Raw['Heat Input (mmBtu)'] = pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0)
+    ARP_Raw['Heat Input (mmBtu)'] = (
+        pd.to_numeric(
+            ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0)
+    )
 
     # Calculate CH4 flux for each facility
     ARP_Raw = (
@@ -188,13 +198,15 @@ def task_get_reporting_electric_coal_proxy_data(
         ARP_Raw.assign(
             ch4_flux=ARP_Raw['Heat Input (mmBtu)'] * ARP_Raw['ch4_f']
             )
-        .drop(columns=['Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
-                       'unit_clean', 'ch4_f', 'fuel_clean'])
-        .rename(columns={'Facility ID': 'facility_id',
-                         'Facility Name': 'facility_name',
-                         'State': 'state_code',
-                         'Year': 'year',
-                         'Month': 'month'})
+        .drop(columns=[
+            'Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
+            'unit_clean', 'ch4_f', 'fuel_clean'])
+        .rename(columns={
+            'Facility ID': 'facility_id',
+            'Facility Name': 'facility_name',
+            'State': 'state_code',
+            'Year': 'year',
+            'Month': 'month'})
         .groupby(['facility_id', 'facility_name', 'state_code', 'year', 'month'])
         .sum('ch4_flux')
         .sort_values(['facility_id', 'year', 'month'])
@@ -202,14 +214,60 @@ def task_get_reporting_electric_coal_proxy_data(
         )
 
     # Merge with ARP Facility Data
-    ARP_Full = (
+    proxy_gdf = (
         ARP_Clean.merge(ARP_Facility_gdf[['facility_id', 'geometry']],
                         on='facility_id', how='left')
     )
 
-    ARP_Full = gpd.GeoDataFrame(ARP_Full, geometry='geometry', crs=4326)
+    proxy_gdf = gpd.GeoDataFrame(proxy_gdf, geometry='geometry', crs=4326)
 
-    ARP_Full.to_parquet(reporting_electric_coal_proxy_output_path)
+    # Add year_month
+    proxy_gdf = (
+        proxy_gdf.assign(
+            year_month=lambda df: df["year"].astype(str)
+            + "-"
+            + df["month"].astype(str)
+            )
+            )
+
+    # Normalize relative emissions to sum to 1 for each year and state
+    # Drop state-years with 0 total volume
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year_month'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    # Normalize annual state emissions to sum to 1
+    proxy_gdf['annual_rel_emi'] = (
+        proxy_gdf.groupby(['year', 'state_code'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year"])["annual_rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Normalize monthly state emissions to sum to 1
+    proxy_gdf['rel_emi'] = (
+        proxy_gdf.groupby(['state_code', 'year_month'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year_month"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Add year_month column for monthly emissions
+    proxy_gdf = (
+        proxy_gdf.drop(columns='ch4_flux')
+        .loc[
+            :,
+            ["facility_id", "facility_name", "state_code", "year_month", "year",
+             "month", "annual_rel_emi", "rel_emi", "geometry"]]
+    )
+
+    proxy_gdf.to_parquet(reporting_elec_coal_path_output_path)
     return None
 
 
@@ -219,8 +277,8 @@ def task_get_reporting_electric_coal_proxy_data(
 @mark.persist
 @task(id='elec_gas_proxy')
 def task_get_reporting_electric_gas_proxy_data(
-    facility_path=EPA_ARP_facilities,
-    input_path=EPA_ARP_inputfile,
+    facility_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022_Facility_Info.csv",
+    input_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022.csv",
     reporting_electric_gas_proxy_output_path: Annotated[Path, Product] = proxy_data_dir_path 
     / 'elec_gas_proxy.parquet'
 ):
@@ -232,7 +290,11 @@ def task_get_reporting_electric_gas_proxy_data(
     # Read in ARP Facility Data
     ARP_Facility = (
         pd.read_csv(facility_path, index_col=False)
-        .filter(items=['Facility ID', 'Facility Name', 'State', 'Latitude', 'Longitude'])
+        .filter(items=[
+            'Facility ID',
+            'Facility Name',
+            'State', 'Latitude',
+            'Longitude'])
         .drop_duplicates(['Facility ID', 'Latitude', 'Longitude'], keep='last')
         .rename(columns={'Facility ID': 'facility_id'})
         .reset_index(drop=True)
@@ -252,8 +314,9 @@ def task_get_reporting_electric_gas_proxy_data(
     # Read in Raw ARP Data & Clean Fuel Type
     ARP_Raw = (
         pd.read_csv(input_path, index_col=False)
-        .filter(items=['State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
-                       'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
+        .filter(items=[
+            'State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
+            'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
         .query('State not in ["VI", "MP", "GU", "AS", "PR", "AK", "HI"]')
     )
 
@@ -261,11 +324,16 @@ def task_get_reporting_electric_gas_proxy_data(
         ARP_Raw.assign(
             unit_clean=np.select(
                 [
-                    ARP_Raw['Unit Type'].str.contains('combustion turbine', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('combined cycle', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('wet bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('dry bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('bubbling', case=False, na=False)
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combustion turbine', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combined cycle', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'wet bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'dry bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'bubbling', case=False, na=False)
                 ],
                 [
                     'combustion turbine',
@@ -278,30 +346,34 @@ def task_get_reporting_electric_gas_proxy_data(
             ),
             fuel_clean=np.select(
                 [
-                    ARP_Raw['Primary Fuel Type'].isin(['Pipeline Natural Gas',
-                                                       'Natural Gas',
-                                                       'Other Gas',
-                                                       'Other Gas, Pipeline Natural Gas',
-                                                       'Natural Gas, Pipeline Natural Gas',
-                                                       'Process Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Petroleum Coke',
-                                                       'Coal',
-                                                       'Coal, Pipeline Natural Gas',
-                                                       'Coal, Natural Gas',
-                                                       'Coal, Wood',
-                                                       'Coal, Coal Refuse',
-                                                       'Coal Refuse',
-                                                       'Coal, Process Gas',
-                                                       'Coal, Diesel Oil',
-                                                       'Other Solid Fuel']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Other Oil',
-                                                       'Diesel Oil',
-                                                       'Diesel Oil, Residual Oil',
-                                                       'Diesel Oil, Pipeline Natural Gas',
-                                                       'Residual Oil',
-                                                       'Residual Oil, Pipeline Natural Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Wood',
-                                                       'Other Solid Fuel, Wood'])
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Pipeline Natural Gas',
+                        'Natural Gas',
+                        'Other Gas',
+                        'Other Gas, Pipeline Natural Gas',
+                        'Natural Gas, Pipeline Natural Gas',
+                        'Process Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Petroleum Coke',
+                        'Coal',
+                        'Coal, Pipeline Natural Gas',
+                        'Coal, Natural Gas',
+                        'Coal, Wood',
+                        'Coal, Coal Refuse',
+                        'Coal Refuse',
+                        'Coal, Process Gas',
+                        'Coal, Diesel Oil',
+                        'Other Solid Fuel']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Other Oil',
+                        'Diesel Oil',
+                        'Diesel Oil, Residual Oil',
+                        'Diesel Oil, Pipeline Natural Gas',
+                        'Residual Oil',
+                        'Residual Oil, Pipeline Natural Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Wood',
+                        'Other Solid Fuel, Wood'])
                 ],
                 [
                     'Gas',
@@ -316,7 +388,8 @@ def task_get_reporting_electric_gas_proxy_data(
     )
 
     # Coerce Heat Input (mmBtu)
-    ARP_Raw['Heat Input (mmBtu)'] = pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0)
+    ARP_Raw['Heat Input (mmBtu)'] = (
+        pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0))
 
     # Calculate CH4 flux for each facility
     ARP_Raw = (
@@ -326,7 +399,9 @@ def task_get_reporting_electric_gas_proxy_data(
                     # For Gas
                     (ARP_Raw['fuel_clean'] == 'Gas') &
                     (ARP_Raw['unit_clean'] == 'combined cycle') |
-                    (ARP_Raw['unit_clean'].str.contains('turbine', case=False, na=False)),
+                    (ARP_Raw['unit_clean'].str.contains('turbine',
+                                                        case=False,
+                                                        na=False)),
 
                     (ARP_Raw['fuel_clean'] == 'Gas')
                 ],
@@ -343,13 +418,15 @@ def task_get_reporting_electric_gas_proxy_data(
         ARP_Raw.assign(
             ch4_flux=ARP_Raw['Heat Input (mmBtu)'] * ARP_Raw['ch4_f']
             )
-        .drop(columns=['Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
-                       'unit_clean', 'ch4_f', 'fuel_clean'])
-        .rename(columns={'Facility ID': 'facility_id',
-                         'Facility Name': 'facility_name',
-                         'State': 'state_code',
-                         'Year': 'year',
-                         'Month': 'month'})
+        .drop(columns=[
+            'Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
+            'unit_clean', 'ch4_f', 'fuel_clean'])
+        .rename(columns={
+            'Facility ID': 'facility_id',
+            'Facility Name': 'facility_name',
+            'State': 'state_code',
+            'Year': 'year',
+            'Month': 'month'})
         .groupby(['facility_id', 'facility_name', 'state_code', 'year', 'month'])
         .sum('ch4_flux')
         .sort_values(['facility_id', 'year', 'month'])
@@ -357,24 +434,71 @@ def task_get_reporting_electric_gas_proxy_data(
         )
 
     # Merge with ARP Facility Data
-    ARP_Full = (
+    proxy_gdf = (
         ARP_Clean.merge(ARP_Facility_gdf[['facility_id', 'geometry']],
                         on='facility_id', how='left')
     )
 
-    ARP_Full = gpd.GeoDataFrame(ARP_Full, geometry='geometry', crs=4326)
+    proxy_gdf = gpd.GeoDataFrame(proxy_gdf, geometry='geometry', crs=4326)
 
-    ARP_Full.to_parquet(reporting_electric_gas_proxy_output_path)
+    # Add year_month
+    proxy_gdf = (
+        proxy_gdf.assign(
+            year_month=lambda df: df["year"].astype(str)
+            + "-"
+            + df["month"].astype(str)
+            )
+            )
+
+    # Normalize relative emissions to sum to 1 for each year and state
+    # Drop state-years with 0 total volume
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year_month'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    # Normalize annual state emissions to sum to 1
+    proxy_gdf['annual_rel_emi'] = (
+        proxy_gdf.groupby(['year', 'state_code'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year"])["annual_rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Normalize monthly state emissions to sum to 1
+    proxy_gdf['rel_emi'] = (
+        proxy_gdf.groupby(['state_code', 'year_month'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year_month"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Add year_month column for monthly emissions
+    proxy_gdf = (
+        proxy_gdf.drop(columns='ch4_flux')
+        .loc[
+            :,
+            ["facility_id", "facility_name", "state_code", "year_month", "year",
+             "month", "annual_rel_emi", "rel_emi", "geometry"]]
+    )
+
+    proxy_gdf.to_parquet(reporting_electric_gas_proxy_output_path)
     return None
 
 ########################################################################################
 # %% elec_oil_proxy
 
+
 @mark.persist
 @task(id='elec_oil_proxy')
 def task_get_reporting_electric_oil_proxy_data(
-    facility_path=EPA_ARP_facilities,
-    input_path=EPA_ARP_inputfile,
+    facility_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022_Facility_Info.csv",
+    input_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022.csv",
     reporting_electric_oil_proxy_output_path: Annotated[Path, Product] = proxy_data_dir_path 
     / 'elec_oil_proxy.parquet'
 ):
@@ -386,7 +510,12 @@ def task_get_reporting_electric_oil_proxy_data(
     # Read in ARP Facility Data
     ARP_Facility = (
         pd.read_csv(facility_path, index_col=False)
-        .filter(items=['Facility ID', 'Facility Name', 'State', 'Latitude', 'Longitude'])
+        .filter(items=[
+            'Facility ID',
+            'Facility Name',
+            'State',
+            'Latitude',
+            'Longitude'])
         .drop_duplicates(['Facility ID', 'Latitude', 'Longitude'], keep='last')
         .rename(columns={'Facility ID': 'facility_id'})
         .reset_index(drop=True)
@@ -406,8 +535,9 @@ def task_get_reporting_electric_oil_proxy_data(
     # Read in Raw ARP Data & Clean Fuel Type
     ARP_Raw = (
         pd.read_csv(input_path, index_col=False)
-        .filter(items=['State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
-                       'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
+        .filter(items=[
+            'State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
+            'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
         .query('State not in ["VI", "MP", "GU", "AS", "PR", "AK", "HI"]')
     )
 
@@ -415,11 +545,16 @@ def task_get_reporting_electric_oil_proxy_data(
         ARP_Raw.assign(
             unit_clean=np.select(
                 [
-                    ARP_Raw['Unit Type'].str.contains('combustion turbine', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('combined cycle', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('wet bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('dry bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('bubbling', case=False, na=False)
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combustion turbine', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combined cycle', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'wet bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'dry bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'bubbling', case=False, na=False)
                 ],
                 [
                     'combustion turbine',
@@ -432,30 +567,34 @@ def task_get_reporting_electric_oil_proxy_data(
             ),
             fuel_clean=np.select(
                 [
-                    ARP_Raw['Primary Fuel Type'].isin(['Pipeline Natural Gas',
-                                                       'Natural Gas',
-                                                       'Other Gas',
-                                                       'Other Gas, Pipeline Natural Gas',
-                                                       'Natural Gas, Pipeline Natural Gas',
-                                                       'Process Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Petroleum Coke',
-                                                       'Coal',
-                                                       'Coal, Pipeline Natural Gas',
-                                                       'Coal, Natural Gas',
-                                                       'Coal, Wood',
-                                                       'Coal, Coal Refuse',
-                                                       'Coal Refuse',
-                                                       'Coal, Process Gas',
-                                                       'Coal, Diesel Oil',
-                                                       'Other Solid Fuel']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Other Oil',
-                                                       'Diesel Oil',
-                                                       'Diesel Oil, Residual Oil',
-                                                       'Diesel Oil, Pipeline Natural Gas',
-                                                       'Residual Oil',
-                                                       'Residual Oil, Pipeline Natural Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Wood',
-                                                       'Other Solid Fuel, Wood'])
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Pipeline Natural Gas',
+                        'Natural Gas',
+                        'Other Gas',
+                        'Other Gas, Pipeline Natural Gas',
+                        'Natural Gas, Pipeline Natural Gas',
+                        'Process Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Petroleum Coke',
+                        'Coal',
+                        'Coal, Pipeline Natural Gas',
+                        'Coal, Natural Gas',
+                        'Coal, Wood',
+                        'Coal, Coal Refuse',
+                        'Coal Refuse',
+                        'Coal, Process Gas',
+                        'Coal, Diesel Oil',
+                        'Other Solid Fuel']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Other Oil',
+                        'Diesel Oil',
+                        'Diesel Oil, Residual Oil',
+                        'Diesel Oil, Pipeline Natural Gas',
+                        'Residual Oil',
+                        'Residual Oil, Pipeline Natural Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Wood',
+                        'Other Solid Fuel, Wood'])
                 ],
                 [
                     'Gas',
@@ -470,7 +609,8 @@ def task_get_reporting_electric_oil_proxy_data(
     )
 
     # Coerce Heat Input (mmBtu)
-    ARP_Raw['Heat Input (mmBtu)'] = pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0)
+    ARP_Raw['Heat Input (mmBtu)'] = (
+        pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0))
 
     # Calculate CH4 flux for each facility
     ARP_Raw = (
@@ -479,7 +619,9 @@ def task_get_reporting_electric_oil_proxy_data(
                 [
                     # For Oil
                     (ARP_Raw['fuel_clean'] == 'Oil') &
-                    (ARP_Raw['Primary Fuel Type'].isin(['Residual Oil', 'Residual Oil, Pipeline Natural Gas'])),
+                    (ARP_Raw['Primary Fuel Type'].isin([
+                        'Residual Oil',
+                        'Residual Oil, Pipeline Natural Gas'])),
 
                     (ARP_Raw['fuel_clean'] == 'Oil')
                 ],
@@ -497,13 +639,15 @@ def task_get_reporting_electric_oil_proxy_data(
         ARP_Raw.assign(
             ch4_flux=ARP_Raw['Heat Input (mmBtu)'] * ARP_Raw['ch4_f']
             )
-        .drop(columns=['Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
-                       'unit_clean', 'ch4_f', 'fuel_clean'])
-        .rename(columns={'Facility ID': 'facility_id',
-                         'Facility Name': 'facility_name',
-                         'State': 'state_code',
-                         'Year': 'year',
-                         'Month': 'month'})
+        .drop(columns=[
+            'Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
+            'unit_clean', 'ch4_f', 'fuel_clean'])
+        .rename(columns={
+            'Facility ID': 'facility_id',
+            'Facility Name': 'facility_name',
+            'State': 'state_code',
+            'Year': 'year',
+            'Month': 'month'})
         .groupby(['facility_id', 'facility_name', 'state_code', 'year', 'month'])
         .sum('ch4_flux')
         .sort_values(['facility_id', 'year', 'month'])
@@ -511,14 +655,60 @@ def task_get_reporting_electric_oil_proxy_data(
         )
 
     # Merge with ARP Facility Data
-    ARP_Full = (
+    proxy_gdf = (
         ARP_Clean.merge(ARP_Facility_gdf[['facility_id', 'geometry']],
                         on='facility_id', how='left')
     )
 
-    ARP_Full = gpd.GeoDataFrame(ARP_Full, geometry='geometry', crs=4326)
+    proxy_gdf = gpd.GeoDataFrame(proxy_gdf, geometry='geometry', crs=4326)
 
-    ARP_Full.to_parquet(reporting_electric_oil_proxy_output_path)
+    # Add year_month
+    proxy_gdf = (
+        proxy_gdf.assign(
+            year_month=lambda df: df["year"].astype(str)
+            + "-"
+            + df["month"].astype(str)
+            )
+            )
+
+    # Normalize relative emissions to sum to 1 for each year and state
+    # Drop state-years with 0 total volume
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year_month'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    # Normalize annual state emissions to sum to 1
+    proxy_gdf['annual_rel_emi'] = (
+        proxy_gdf.groupby(['year', 'state_code'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year"])["annual_rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Normalize monthly state emissions to sum to 1
+    proxy_gdf['rel_emi'] = (
+        proxy_gdf.groupby(['state_code', 'year_month'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year_month"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Add year_month column for monthly emissions
+    proxy_gdf = (
+        proxy_gdf.drop(columns='ch4_flux')
+        .loc[
+            :,
+            ["facility_id", "facility_name", "state_code", "year_month", "year",
+             "month", "annual_rel_emi", "rel_emi", "geometry"]]
+    )
+
+    proxy_gdf.to_parquet(reporting_electric_oil_proxy_output_path)
     return None
 
 
@@ -528,8 +718,8 @@ def task_get_reporting_electric_oil_proxy_data(
 @mark.persist
 @task(id='elec_wood_proxy')
 def task_get_reporting_electric_wood_proxy_data(
-    facility_path=EPA_ARP_facilities,
-    input_path=EPA_ARP_inputfile,
+    facility_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022_Facility_Info.csv",
+    input_path: Path = sector_data_dir_path / "combustion_stationary/ARP_Data/EPA_ARP_2012-2022.csv",
     reporting_electric_wood_proxy_output_path: Annotated[Path, Product] = proxy_data_dir_path 
     / 'elec_wood_proxy.parquet'
 ):
@@ -541,7 +731,12 @@ def task_get_reporting_electric_wood_proxy_data(
     # Read in ARP Facility Data
     ARP_Facility = (
         pd.read_csv(facility_path, index_col=False)
-        .filter(items=['Facility ID', 'Facility Name', 'State', 'Latitude', 'Longitude'])
+        .filter(items=[
+            'Facility ID',
+            'Facility Name',
+            'State',
+            'Latitude',
+            'Longitude'])
         .drop_duplicates(['Facility ID', 'Latitude', 'Longitude'], keep='last')
         .rename(columns={'Facility ID': 'facility_id'})
         .reset_index(drop=True)
@@ -561,8 +756,9 @@ def task_get_reporting_electric_wood_proxy_data(
     # Read in Raw ARP Data & Clean Fuel Type
     ARP_Raw = (
         pd.read_csv(input_path, index_col=False)
-        .filter(items=['State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
-                       'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
+        .filter(items=[
+            'State', 'Facility ID', 'Facility Name', 'Unit ID', 'Year', 'Month',
+            'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type'])
         .query('State not in ["VI", "MP", "GU", "AS", "PR", "AK", "HI"]')
     )
 
@@ -570,11 +766,16 @@ def task_get_reporting_electric_wood_proxy_data(
         ARP_Raw.assign(
             unit_clean=np.select(
                 [
-                    ARP_Raw['Unit Type'].str.contains('combustion turbine', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('combined cycle', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('wet bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('dry bottom', case=False, na=False),
-                    ARP_Raw['Unit Type'].str.contains('bubbling', case=False, na=False)
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combustion turbine', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'combined cycle', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'wet bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'dry bottom', case=False, na=False),
+                    ARP_Raw['Unit Type'].str.contains(
+                        'bubbling', case=False, na=False)
                 ],
                 [
                     'combustion turbine',
@@ -587,30 +788,34 @@ def task_get_reporting_electric_wood_proxy_data(
             ),
             fuel_clean=np.select(
                 [
-                    ARP_Raw['Primary Fuel Type'].isin(['Pipeline Natural Gas',
-                                                       'Natural Gas',
-                                                       'Other Gas',
-                                                       'Other Gas, Pipeline Natural Gas',
-                                                       'Natural Gas, Pipeline Natural Gas',
-                                                       'Process Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Petroleum Coke',
-                                                       'Coal',
-                                                       'Coal, Pipeline Natural Gas',
-                                                       'Coal, Natural Gas',
-                                                       'Coal, Wood',
-                                                       'Coal, Coal Refuse',
-                                                       'Coal Refuse',
-                                                       'Coal, Process Gas',
-                                                       'Coal, Diesel Oil',
-                                                       'Other Solid Fuel']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Other Oil',
-                                                       'Diesel Oil',
-                                                       'Diesel Oil, Residual Oil',
-                                                       'Diesel Oil, Pipeline Natural Gas',
-                                                       'Residual Oil',
-                                                       'Residual Oil, Pipeline Natural Gas']),
-                    ARP_Raw['Primary Fuel Type'].isin(['Wood',
-                                                       'Other Solid Fuel, Wood'])
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Pipeline Natural Gas',
+                        'Natural Gas',
+                        'Other Gas',
+                        'Other Gas, Pipeline Natural Gas',
+                        'Natural Gas, Pipeline Natural Gas',
+                        'Process Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Petroleum Coke',
+                        'Coal',
+                        'Coal, Pipeline Natural Gas',
+                        'Coal, Natural Gas',
+                        'Coal, Wood',
+                        'Coal, Coal Refuse',
+                        'Coal Refuse',
+                        'Coal, Process Gas',
+                        'Coal, Diesel Oil',
+                        'Other Solid Fuel']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Other Oil',
+                        'Diesel Oil',
+                        'Diesel Oil, Residual Oil',
+                        'Diesel Oil, Pipeline Natural Gas',
+                        'Residual Oil',
+                        'Residual Oil, Pipeline Natural Gas']),
+                    ARP_Raw['Primary Fuel Type'].isin([
+                        'Wood',
+                        'Other Solid Fuel, Wood'])
                 ],
                 [
                     'Gas',
@@ -625,7 +830,8 @@ def task_get_reporting_electric_wood_proxy_data(
     )
 
     # Coerce Heat Input (mmBtu)
-    ARP_Raw['Heat Input (mmBtu)'] = pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0)
+    ARP_Raw['Heat Input (mmBtu)'] = (
+        pd.to_numeric(ARP_Raw['Heat Input (mmBtu)'], errors='coerce').fillna(0))
 
     # Calculate CH4 flux for each facility
     ARP_Raw = (
@@ -648,13 +854,15 @@ def task_get_reporting_electric_wood_proxy_data(
         ARP_Raw.assign(
             ch4_flux=ARP_Raw['Heat Input (mmBtu)'] * ARP_Raw['ch4_f']
             )
-        .drop(columns=['Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
-                       'unit_clean', 'ch4_f', 'fuel_clean'])
-        .rename(columns={'Facility ID': 'facility_id',
-                         'Facility Name': 'facility_name',
-                         'State': 'state_code',
-                         'Year': 'year',
-                         'Month': 'month'})
+        .drop(columns=[
+            'Unit ID', 'Heat Input (mmBtu)', 'Primary Fuel Type', 'Unit Type',
+            'unit_clean', 'ch4_f', 'fuel_clean'])
+        .rename(columns={
+            'Facility ID': 'facility_id',
+            'Facility Name': 'facility_name',
+            'State': 'state_code',
+            'Year': 'year',
+            'Month': 'month'})
         .groupby(['facility_id', 'facility_name', 'state_code', 'year', 'month'])
         .sum('ch4_flux')
         .sort_values(['facility_id', 'year', 'month'])
@@ -662,14 +870,60 @@ def task_get_reporting_electric_wood_proxy_data(
         )
 
     # Merge with ARP Facility Data
-    ARP_Full = (
+    proxy_gdf = (
         ARP_Clean.merge(ARP_Facility_gdf[['facility_id', 'geometry']],
                         on='facility_id', how='left')
     )
 
-    ARP_Full = gpd.GeoDataFrame(ARP_Full, geometry='geometry', crs=4326)
+    proxy_gdf = gpd.GeoDataFrame(proxy_gdf, geometry='geometry', crs=4326)
 
-    ARP_Full.to_parquet(reporting_electric_wood_proxy_output_path)
+    # Add year_month
+    proxy_gdf = (
+        proxy_gdf.assign(
+            year_month=lambda df: df["year"].astype(str)
+            + "-"
+            + df["month"].astype(str)
+            )
+            )
+
+    # Normalize relative emissions to sum to 1 for each year and state
+    # Drop state-years with 0 total volume
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year_month'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    # Normalize annual state emissions to sum to 1
+    proxy_gdf['annual_rel_emi'] = (
+        proxy_gdf.groupby(['year', 'state_code'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year"])["annual_rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Normalize monthly state emissions to sum to 1
+    proxy_gdf['rel_emi'] = (
+        proxy_gdf.groupby(['state_code', 'year_month'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    sums = proxy_gdf.groupby(["state_code", "year_month"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Add year_month column for monthly emissions
+    proxy_gdf = (
+        proxy_gdf.drop(columns='ch4_flux')
+        .loc[
+            :,
+            ["facility_id", "facility_name", "state_code", "year_month", "year",
+             "month", "annual_rel_emi", "rel_emi", "geometry"]]
+    )
+
+    proxy_gdf.to_parquet(reporting_electric_wood_proxy_output_path)
     return None
 
 
@@ -679,10 +933,10 @@ def task_get_reporting_electric_wood_proxy_data(
 @mark.persist
 @task(id='indu_proxy')
 def task_get_reporting_indu_proxy_data(
-    subpart_C=GHGRP_subC_inputfile,
-    subpart_D=GHGRP_subD_inputfile,
-    facility_path=GHGRP_subDfacility_loc_inputfile,
-    reporting_indu_proxy_output_path: Annotated[Path, Product] = proxy_data_dir_path
+    subpart_C: Path = sector_data_dir_path / "combustion_stationary/GHGRP/GHGRP_SubpartCEmissions_2010-2023.csv",
+    subpart_D: Path = sector_data_dir_path / "combustion_stationary/GHGRP/GHGRP_SubpartDEmissions_2010-2023.csv",
+    facility_path: Path = sector_data_dir_path / "combustion_stationary/GHGRP/GHGRP_FacilityInfo_2010-2023.csv",
+    reporting_indu_output_path: Annotated[Path, Product] = proxy_data_dir_path
     / 'indu_proxy.parquet'
 ):
     """
@@ -692,7 +946,7 @@ def task_get_reporting_indu_proxy_data(
 
     # Read in Subpart C
     GHGRP_C = (
-        pd.read_csv(GHGRP_subC_inputfile, index_col=False)
+        pd.read_csv(subpart_C, index_col=False)
         .query('ghg_gas_name == "Methane"')
         .query('reporting_year >= @min_year & reporting_year <= @max_year')
         .drop(columns='ghg_gas_name')
@@ -700,7 +954,7 @@ def task_get_reporting_indu_proxy_data(
     )
     # Read in Subpart D
     GHGRP_D = (
-        pd.read_csv(GHGRP_subD_inputfile, index_col=False)
+        pd.read_csv(subpart_D, index_col=False)
         .query('ghg_name == "Methane"')
         .drop_duplicates(subset=['facility_id'])
         .reset_index(drop=True)
@@ -722,7 +976,7 @@ def task_get_reporting_indu_proxy_data(
     # Read in Facility List
     # Keep most recent unique facility info (no year)
     GHGRP_Facilities = (
-        pd.read_csv(GHGRP_subDfacility_loc_inputfile, index_col=False)
+        pd.read_csv(facility_path, index_col=False)
         .sort_values(by=['facility_id', 'year'], ascending=[True, False])
         .drop_duplicates(subset=['facility_id'], keep='first')
         .drop(columns='year')
@@ -730,7 +984,7 @@ def task_get_reporting_indu_proxy_data(
     )
 
     # Merge C_Only with Facility Info
-    indu_proxy = (
+    proxy_gdf = (
         GHGRP_C_Only.merge(
             GHGRP_Facilities,
             on='facility_id'
@@ -744,23 +998,45 @@ def task_get_reporting_indu_proxy_data(
         )
         # Convert Metrtic Tons to KT (1 KT = 1000 Metric Tons)
         .assign(
-            rel_emi=lambda df: df["ghg_quantity"] / 1000
+            ch4_flux=lambda df: df["ghg_quantity"] / 1000
         )
-        [['facility_id', 'facility_name', 'state_code', 'year', 'rel_emi', 'latitude', 'longitude']]
+        [[
+            'facility_id',
+            'facility_name',
+            'state_code',
+            'year',
+            'ch4_flux',
+            'latitude',
+            'longitude'
+            ]]
         .reset_index(drop=True)
     )
 
-    indu_proxy = (
+    proxy_gdf = (
         gpd.GeoDataFrame(
-            indu_proxy,
+            proxy_gdf,
             geometry=gpd.points_from_xy(
-                indu_proxy['longitude'],
-                indu_proxy['latitude'],
+                proxy_gdf['longitude'],
+                proxy_gdf['latitude'],
                 crs=4326
             )
         )
         .drop(columns=['latitude', 'longitude'])
     )
 
-    indu_proxy.to_parquet(reporting_indu_proxy_output_path)
+    # Normalize relative emissions to sum to 1 for each year and state
+    # Drop state-years with 0 total volume
+    proxy_gdf = (
+        proxy_gdf.groupby(['state_code', 'year'])
+        .filter(lambda x: x['ch4_flux'].sum() > 0)
+    )
+    # Normalize annual state emissions to sum to 1
+    proxy_gdf['annual_rel_emi'] = (
+        proxy_gdf.groupby(['year', 'state_code'])['ch4_flux']
+        .transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    )
+    # Drop the original ch4_flux column
+    proxy_gdf = proxy_gdf.drop(columns=['ch4_flux'])
+
+    proxy_gdf.to_parquet(reporting_indu_output_path)
     return None

--- a/gch4i/proxy_processing/task_trans_pipelines_proxy.py
+++ b/gch4i/proxy_processing/task_trans_pipelines_proxy.py
@@ -2,13 +2,19 @@
 Name:                   task_trans_pipelines_proxy.py
 Date Last Modified:     2025-02-07
 Authors Name:           John Bollenbacher (RTI International)
-Purpose:                This file builds spatial proxies for natural gas pipelines on farmlands. 
-                        Reads pipeline geometries, splits them by state,
-                        and saves out a table of the resulting pipeline geometries for each year and state.
-Input Files:            - {sector_data_dir_path}/enverus/midstream/Rextag_Natural_Gas.gdb
-                        - {V3_DATA_PATH}/geospatial/cb_2018_us_state_500k/cb_2018_us_state_500k.shp
+Purpose:                This file builds spatial proxies for natural gas pipelines on
+                            farmlands.
+                        Reads pipeline geometries, splits them by state, and saves out
+                            a table of the resulting pipeline geometries for each year
+                            and state.
+Input Files:            - {sector_data_dir_path}/enverus/midstream/
+                            Rextag_Natural_Gas.gdb
+                        - {V3_DATA_PATH}/geospatial/cb_2018_us_state_500k/
+                            cb_2018_us_state_500k.shp
 Output Files:           - farm_pipelines_proxy.parquet
 """
+
+# %% Import Libraries
 from pathlib import Path
 from typing import Annotated
 
@@ -18,29 +24,21 @@ import numpy as np
 from pytask import Product, mark, task
 
 from gch4i.config import (
+    global_data_dir_path,
     max_year,
     min_year,
     proxy_data_dir_path,
-    sector_data_dir_path,
-    V3_DATA_PATH
-)
-from gch4i.utils import (
-    us_state_to_abbrev_dict
+    sector_data_dir_path
 )
 
-lower_48_and_DC = ('AL', 'AR', 'AZ', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'IA', 'ID', 'IL', 
-            'IN', 'KS', 'KY', 'LA', 'MA', 'MD', 'ME', 'MI', 'MN', 'MO', 'MS', 'MT',
-            'NC', 'ND', 'NE', 'NH', 'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA',
-            'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VA', 'VT', 'WA', 'WI', 'WV', 'WY', 'DC')
 
+# %% Pytask Function
 @mark.persist
 @task(id="trans_pipeline_proxy")
 def get_trans_pipeline_proxy_data(
-    #Inputs
-    enverus_midstream_pipelines_path: Path = sector_data_dir_path / "enverus/midstream/Rextag_Natural_Gas.gdb",
-    state_shapes_path: Path = V3_DATA_PATH / 'geospatial/cb_2018_us_state_500k/cb_2018_us_state_500k.shp'
-
-    #Outputs
+    # Inputs
+    state_path: Path = global_data_dir_path / "tl_2020_us_state.zip",
+    # Outputs
     output_path: Annotated[Path, Product] = (
         proxy_data_dir_path / "trans_pipelines_proxy.parquet"
     ),
@@ -49,28 +47,42 @@ def get_trans_pipeline_proxy_data(
     # Load data
     ###############################################################
 
-    # load state geometries for continental US
-    state_shapes = gpd.read_file(state_shapes_path)
-    state_shapes = state_shapes.rename(columns={'STUSPS': 'state_code'})[['state_code', 'geometry']]
-    state_shapes = state_shapes[state_shapes['state_code'].isin(lower_48_and_DC)]
-    state_shapes = state_shapes.to_crs(epsg=4326)  # Ensure state_shapes is in EPSG:4326
+    # Input path cannnot be in function because it is a directory, not a file
+    enverus_midstream_pipelines_path: Path = sector_data_dir_path / "enverus/midstream/Rextag_Natural_Gas.gdb"
+
+    # Load state shapes
+    state_shapes = (
+        gpd.read_file(state_path)
+        .rename(columns={"STUSPS": "state_code"})
+        .astype({"STATEFP": int})
+        # get only lower 48 + DC
+        .query("(STATEFP < 60) & (STATEFP != 2) & (STATEFP != 15)")
+        .loc[:, ["state_code", "geometry"]]
+        .to_crs(epsg=4326)
+    )
 
     # load enverus pipelines geometries data
-    enverus_pipelines_gdf = gpd.read_file(enverus_midstream_pipelines_path, layer='NaturalGasPipelines')
-    enverus_pipelines_gdf = enverus_pipelines_gdf.to_crs(epsg=4326)  # Ensure enverus_pipelines_gdf is in EPSG:4326
+    enverus_pipelines_gdf = gpd.read_file(
+        enverus_midstream_pipelines_path, layer='NaturalGasPipelines')
+    # Ensure enverus_pipelines_gdf is in EPSG:4326
+    enverus_pipelines_gdf = enverus_pipelines_gdf.to_crs(epsg=4326)
 
-    #drop unneeded pipelines and columns
+    # drop unneeded pipelines and columns
     # enverus_pipelines_gdf = enverus_pipelines_gdf[enverus_pipelines_gdf['CNTRY_NAME']=='United States'] #dropped, because not used in v2 and state intersection will filter this.
-    enverus_pipelines_gdf = enverus_pipelines_gdf[enverus_pipelines_gdf['STATUS']=='Operational']
-    enverus_pipelines_gdf = enverus_pipelines_gdf[enverus_pipelines_gdf['TYPE'] =='Transmission']
-    enverus_pipelines_gdf = enverus_pipelines_gdf[['LOC_ID','DIAMETER','geometry', #'INSTALL_YR',
+    enverus_pipelines_gdf = enverus_pipelines_gdf[enverus_pipelines_gdf['STATUS'] == 'Operational']
+    enverus_pipelines_gdf = enverus_pipelines_gdf[enverus_pipelines_gdf['TYPE'] == 'Transmission']
+    enverus_pipelines_gdf = enverus_pipelines_gdf[['LOC_ID',
+                                                   'DIAMETER',
+                                                   'geometry'  # ,'INSTALL_YR',
                                                    ]].reset_index(drop=True)
-    
-    # Split pipelines at state boundaries and keep only the segments that fall within states
-    enverus_pipelines_gdf_split_by_state = gpd.overlay(enverus_pipelines_gdf, state_shapes, how='intersection', keep_geom_type=True)
 
-    #create each year's proxy, and combine to make the full proxy table
-    # NOTE: this assumes the geometries do not change year to year, since we dont have good data for when each pipeline began operation. 
+    # Split pipelines at state boundaries and keep only the segments that fall within states
+    enverus_pipelines_gdf_split_by_state = gpd.overlay(
+        enverus_pipelines_gdf, state_shapes, how='intersection', keep_geom_type=True)
+
+    # create each year's proxy, and combine to make the full proxy table
+    # NOTE: this assumes the geometries do not change year to year, since we dont have
+    # good data for when each pipeline began operation.
     year_gdfs = []
     for year in range(min_year, max_year+1):
         year_gdf = enverus_pipelines_gdf_split_by_state.copy()
@@ -79,23 +91,31 @@ def get_trans_pipeline_proxy_data(
         year_gdfs.append(year_gdf)
     proxy_gdf = pd.concat(year_gdfs, ignore_index=True)
 
-    #compute the length of each pipeline within each state
+    # compute the length of each pipeline within each state
     proxy_gdf = proxy_gdf.to_crs("ESRI:102003")  # Convert to ESRI:102003
-    proxy_gdf['pipeline_length_within_state'] = proxy_gdf.geometry.length  
+    proxy_gdf['pipeline_length_within_state'] = proxy_gdf.geometry.length
     proxy_gdf = proxy_gdf.to_crs(epsg=4326)  # Convert back to EPSG:4326
 
-    #get rel_emi
-    proxy_gdf = proxy_gdf.rename(columns = {'pipeline_length_within_state':'rel_emi'}) #simply assume rel_emi is proportional to length.
+    # get rel_emi, simply assume rel_emi is proportional to length.
+    proxy_gdf = proxy_gdf.rename(columns={'pipeline_length_within_state': 'rel_emi'})
 
     ###############################################################
     # Normalize and save
     ###############################################################
 
     # Normalize relative emissions to sum to 1 for each year and state
-    proxy_gdf = proxy_gdf.groupby(['state_code', 'year']).filter(lambda x: x['rel_emi'].sum() > 0) #drop state-years with 0 total volume
-    proxy_gdf['rel_emi'] = proxy_gdf.groupby(['year', 'state_code'])['rel_emi'].transform(lambda x: x / x.sum() if x.sum() > 0 else 0) #normalize to sum to 1
-    sums = proxy_gdf.groupby(["state_code", "year"])["rel_emi"].sum() #get sums to check normalization
-    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}" # assert that the sums are close to 1
+    # drop state-years with 0 total volume
+    proxy_gdf = proxy_gdf.groupby(['year']).filter(lambda x: x['rel_emi'].sum() > 0)
+    # normalize to sum to 1
+    proxy_gdf['rel_emi'] = proxy_gdf.groupby(
+        ['year'])['rel_emi'].transform(lambda x: x / x.sum() if x.sum() > 0 else 0)
+    # get sums to check normalization
+    sums = proxy_gdf.groupby(["year"])["rel_emi"].sum()
+    # assert that the sums are close to 1
+    assert np.isclose(sums, 1.0, atol=1e-8).all(), f"Relative emissions do not sum to 1 for each year and state; {sums}"
+
+    # Drop state_code
+    proxy_gdf = proxy_gdf.drop(columns=['state_code'])
 
     # Save to parquet
     proxy_gdf.to_parquet(output_path)


### PR DESCRIPTION
post_code_review branch crashed/failed due to OneDrive issues. Multiples of files were retained once OneDrive was able to reconnect and it created 2 separate branches, neither of which I could push to.

To resolve, I copied my updated files to a backup directory; pulled main; created a new branch; and am pushing updates from the new (unbroken) branch: national_proxies.

**Re: Nick's feedback from post_code_review**
- the correct `task_abandoned_coal_proxy` was added this time. Last time was an old version from a .scratch directory
- task_field_burning_emi.py was updated to import tg_to_kt, instead of creating it in the code.

Emi Files:
task_iron_steel_emi - Review/updated Chris C's code
task_mobile_comb_emi - Updated code to take in 2022 mobile emi data, provided by EPA
task_petro_production_emi - Removing state_code from offshore emis
task_natural_gas_emis - Removing state_code from offshore emis
task_field_burning_emi - Adjusted code to only include states with atleast one emission. Should cause match between fbar emi/proxy.

Proxy Files:
task_stat_comb_proxy - normalization
task_mob_comb_railroads_proxy - Updated code to fix invalid geoms. May not be necessary to merge if you created different code for the final QC (I believe you did, but I included this just in case).
task_farm_pipelines_proxy - normalization, remove state_code
task_lng_storage_proxy - normalization, remove state_code
task_trans_pipelines_proxy - normalization, remove state_code
task_storage_wells_proxy - normalization, remove state_code
task_ng_transmission_export_proxy - normalization, remove state_code
task_ng_transmission_import_proxy - normalization, remove state_code
task_abandoned_coal_proxy - adjusted code to remove null year values (did not drop at end, adjusted code)