### PR TITLE
Abandoned coal

### DIFF
--- a/gch4i/proxy_processing/task_abandoned_coal_proxy.py
+++ b/gch4i/proxy_processing/task_abandoned_coal_proxy.py
@@ -465,9 +465,7 @@ def task_get_abd_coal_proxy_data(
         "& (date_abd.dt.year < @min_year)"
         "& (reopen_date.dt.year < @min_year)"
     ).sort_values("reopen_date")
-    reference_mines_df = reference_mines_df.drop(
-        index=questionable_mines_df.index
-    )
+    reference_mines_df = reference_mines_df.drop(index=questionable_mines_df.index)
     questionable_mines_df
     # %%
 
@@ -478,9 +476,7 @@ def task_get_abd_coal_proxy_data(
         "& (date_abd.dt.year < @min_year)"
         "& (reopen_date.dt.year < @min_year)"
     ).sort_values("reopen_date")
-    reference_mines_df = reference_mines_df.drop(
-        index=now_closed_mines_df.index
-    )
+    reference_mines_df = reference_mines_df.drop(index=now_closed_mines_df.index)
     now_closed_mines_df
     # %%
     # We also have mines that have an abandoned date but no reopen date, so we assume
@@ -488,9 +484,7 @@ def task_get_abd_coal_proxy_data(
     never_reopened_mines_df = reference_mines_df.query(
         "date_abd.dt.year < @min_year" "& (reopen_date.isna())"
     )
-    reference_mines_df = reference_mines_df.drop(
-        index=never_reopened_mines_df.index
-    )
+    reference_mines_df = reference_mines_df.drop(index=never_reopened_mines_df.index)
     never_reopened_mines_df
 
     # %%
@@ -500,14 +494,17 @@ def task_get_abd_coal_proxy_data(
     abandoned_during_study_df = reference_mines_df.query(
         "(date_abd.dt.year < @min_year) & (reopen_date.dt.year > @max_year)"
     ).sort_values("date_abd")
-    reference_mines_df = reference_mines_df.drop(
-        index=abandoned_during_study_df.index
-    )
+    reference_mines_df = reference_mines_df.drop(index=abandoned_during_study_df.index)
     abandoned_during_study_df
     # %%
 
     always_abandoned_mines_df = pd.concat(
-        [questionable_mines_df, now_closed_mines_df, never_reopened_mines_df, abandoned_during_study_df]
+        [
+            questionable_mines_df,
+            now_closed_mines_df,
+            never_reopened_mines_df,
+            abandoned_during_study_df,
+        ]
     )
     always_abandoned_mines_df.sort_values("date_abd")
 
@@ -518,9 +515,11 @@ def task_get_abd_coal_proxy_data(
         "date_abd.dt.year.between(@min_year, @max_year) | "
         "reopen_date.dt.year.between(@min_year, @max_year)"
     )
-    reference_mines_df = reference_mines_df.drop(
-        index=has_status_change_df.index
+    has_2_status_change_df = has_status_change_df.query(
+        "date_abd.dt.year.between(@min_year, @max_year)"
+        "& reopen_date.dt.year.between(@min_year, @max_year)"
     )
+    reference_mines_df = reference_mines_df.drop(index=has_status_change_df.index)
     has_status_change_df.sort_values("date_abd")
 
     # %%

--- a/gch4i/proxy_processing/task_abandoned_coal_proxy.py
+++ b/gch4i/proxy_processing/task_abandoned_coal_proxy.py
@@ -48,7 +48,7 @@ def task_get_abd_coal_proxy_data(
         ghgi_data_dir_path / "1B1a_abandoned_coal/AbandonedCoalMines1990-2022_FRv1.xlsx"
     ),
     msha_path: Path = sector_data_dir_path / "abandoned_mines/Mines.zip",
-    county_path: str = global_data_dir_path / "tl_2020_us_county.zip",
+    county_path: Path = global_data_dir_path / "tl_2020_us_county.zip",
     state_path: Path = global_data_dir_path / "tl_2020_us_state.zip",
     output_path: Annotated[Path, Product] = (
         proxy_data_dir_path / "abd_coal_proxy.parquet"
@@ -405,7 +405,7 @@ def task_get_abd_coal_proxy_data(
                 "operating_status",
             ],
         ]
-    )
+    ).reset_index(drop=True)
     all_mines_df
 
     # carrying over the guidance from v2, we will remove mines that are listed as active
@@ -433,33 +433,35 @@ def task_get_abd_coal_proxy_data(
     # %%
 
     # %%
-    # actives mines are those that are listed as active and have a reopen date before
-    # the study period. We will remove these from the abandoned mines list.
-    active_mines_df = all_mines_df.query(
-        # "(operating_status == 'Active')"
-        "(operating_status == 'Active') & (reopen_date.dt.year < 2012)"
-        # EEM - why is the re-open date set to 2020 and not a different year? Check
-        # that this isn't a hold-over from v2
-        # NFK: if we adjust this to 2012, then we assume the have reopened and are truly
-        # active during this time period.
-    ).sort_values("reopen_date")
-    print(
-        "mines that are in the abandoned workbook but "
-        f"listed as active in the mine db: {len(active_mines_df)}"
-    )
-    active_mines_df
+    # # actives mines are those that are listed as active and have a reopen date before
+    # # the study period. We will remove these from the abandoned mines list.
+    # active_mines_df = all_mines_df.query(
+    #     # "(operating_status == 'Active')"
+    #     "(operating_status == 'Active') & (reopen_date.dt.year < 2012)"
+    #     # EEM - why is the re-open date set to 2020 and not a different year? Check
+    #     # that this isn't a hold-over from v2
+    #     # NFK: if we adjust this to 2012, then we assume the have reopened and are truly
+    #     # active during this time period.
+    # ).sort_values("reopen_date")
+    # print(
+    #     "mines that are in the abandoned workbook but "
+    #     f"listed as active in the mine db: {len(active_mines_df)}"
+    # )
+    # active_mines_df
     # %%
 
     # remove the active mines from the abandoned mines
     # %%
-    reference_mines_df = all_mines_df.drop(index=active_mines_df.index).reset_index(
-        drop=True
-    )
+    reference_mines_df = all_mines_df.copy()
+    # reference_mines_df = all_mines_df.drop(index=active_mines_df.index).reset_index(
+    #     drop=True
+    # )
     reference_mine_count = len(reference_mines_df)
 
     # questionable mines are those that have a reopen date after the date of
     # abandonment and were reopened prior to the study period.
-    # We are gong to assume these were are abandoned during the entire study period.
+    # We are gong to assume these were are abandoned during the entire study period
+    # dating back to the reported date of abandonment.
     questionable_mines_df = reference_mines_df.query(
         "(reopen_date >= date_abd)"
         "& (date_abd.dt.year < @min_year)"
@@ -467,7 +469,6 @@ def task_get_abd_coal_proxy_data(
     ).sort_values("reopen_date")
     reference_mines_df = reference_mines_df.drop(index=questionable_mines_df.index)
     questionable_mines_df
-    # %%
 
     # now closed minse are those that have a reopen date before the date of
     # abandonment and closed prior to the study period.
@@ -478,7 +479,7 @@ def task_get_abd_coal_proxy_data(
     ).sort_values("reopen_date")
     reference_mines_df = reference_mines_df.drop(index=now_closed_mines_df.index)
     now_closed_mines_df
-    # %%
+
     # We also have mines that have an abandoned date but no reopen date, so we assume
     # they are always abandoned.
     never_reopened_mines_df = reference_mines_df.query(
@@ -487,7 +488,6 @@ def task_get_abd_coal_proxy_data(
     reference_mines_df = reference_mines_df.drop(index=never_reopened_mines_df.index)
     never_reopened_mines_df
 
-    # %%
     # We have mines that were abandoned during the entire study period and have reopened
     # after the study period. We will assume were abandoned
     # during the study period.
@@ -496,8 +496,10 @@ def task_get_abd_coal_proxy_data(
     ).sort_values("date_abd")
     reference_mines_df = reference_mines_df.drop(index=abandoned_during_study_df.index)
     abandoned_during_study_df
-    # %%
 
+    # for all intents and purposes, these mines are always abandoned and we will
+    # calculate emissions based on the date of abandonment. These is the core dataset
+    # that does not need any further processing during the calculation of emissions.
     always_abandoned_mines_df = pd.concat(
         [
             questionable_mines_df,
@@ -505,37 +507,128 @@ def task_get_abd_coal_proxy_data(
             never_reopened_mines_df,
             abandoned_during_study_df,
         ]
-    )
+    ).assign(gepa_status="abandoned")
     always_abandoned_mines_df.sort_values("date_abd")
+    print(
+        f"number of mines that are always abandoned: {len(always_abandoned_mines_df)}"
+    )
 
     # %%
+
+    # We also have mines that have status changes during the study period. These mines
+    # could have several different changes and require attention during the calculation
+    # of emissions.
+
     # we have mines whos status changes during the study period. These are the ones that
     # have to be dealth with the most during the calculations.
     has_status_change_df = reference_mines_df.query(
         "date_abd.dt.year.between(@min_year, @max_year) | "
         "reopen_date.dt.year.between(@min_year, @max_year)"
     )
+
+    print(
+        f"mines with status changes during the study period: {len(has_status_change_df)}"
+    )
+    has_status_change_count = len(has_status_change_df)
+
+    # Some mines report 2 status changes during the study period.
     has_2_status_change_df = has_status_change_df.query(
         "date_abd.dt.year.between(@min_year, @max_year)"
         "& reopen_date.dt.year.between(@min_year, @max_year)"
     )
-    reference_mines_df = reference_mines_df.drop(index=has_status_change_df.index)
-    has_status_change_df.sort_values("date_abd")
+    has_status_change_df = has_status_change_df.drop(index=has_2_status_change_df.index)
 
+    print(
+        f"mines with 2 changes during the study period: {len(has_2_status_change_df)}"
+    )
+    # of the mines with 1 status change, these can either close or reopen during the
+    # study period. We will separate these into two categories:
+    has_status_change_df["gepa_status"] = np.where(
+        has_status_change_df["reopen_date"] <= has_status_change_df["date_abd"],
+        "open",
+        "abandoned",
+    )
+    reopens_during_study_df = has_status_change_df.query("reopen_date > date_abd")
+    print(f"mines that reopen during the study period: {len(reopens_during_study_df)}")
+    closes_during_study_df = has_status_change_df.query("reopen_date <= date_abd")
+    print(f"mines that close during the study period: {len(closes_during_study_df)}")
+
+    # if there are two dates during the study period, these can fall into two
+    # categories:
+    # 1) mines that were abandoned, reopened, and then abandoned again
+    # 2) mines that were open, abandoned, and then reopened
+    open_aban_open_df = has_2_status_change_df.query("reopen_date > date_abd")
+    aban_open_aban_df = has_2_status_change_df.query("reopen_date <= date_abd")
+
+    # reference_mines_df = reference_mines_df.drop(index=has_status_change_df.index)
+    # has_status_change_df.sort_values("date_abd")
+    status_change_count_check = (
+        len(has_2_status_change_df)
+        + len(reopens_during_study_df)
+        + len(closes_during_study_df)
+    ) == has_status_change_count
+
+    print(f"do our numbers for status change add up? {status_change_count_check}")
     # %%
     count_check = (
-        len(always_abandoned_mines_df) + len(has_status_change_df)
+        len(always_abandoned_mines_df) + has_status_change_count
     ) == reference_mine_count
-    print(f"count check: {count_check}")
+    print(
+        f"""
+        {len(always_abandoned_mines_df)} + {has_status_change_count} = {reference_mine_count}
+        do our total numbers add up: {count_check}
+        """
+    )
+    # %%
+    always_abandoned_mines_df["date_abd"].dt.year.value_counts().sort_index().plot(
+        kind="bar"
+    )
+    # %%
+    closes_during_study_df["date_abd"].dt.year.value_counts().sort_index().plot(
+        kind="bar"
+    )
+    # %%
+    reopens_during_study_df["reopen_date"].dt.year.value_counts().sort_index().plot(
+        kind="bar"
+    )
+    # %%
+    """
+    Here we are now holding the following dataframes for processing:
+    -   always_abandoned_mines_df:
+        -   mines that were abandoned prior to the study period and have not reopened.
+        -   These are assumed to be abandoned and we calculate emissions based on the
+            date of abandonment regardless of the reopen date.
+    - reopens_during_study_df:
+        -   mines that have reopened during the study period. These mines will be
+            calculated based on the date of abandonment up to the date of reopen.
+    - closes_during_study_df:
+        -   mines that have closed during the study period. These mines will be be added
+            to the abandoned mines list and calculated based on the date of abandonment.
+    - has_2_status_change_df:
+        -   mines that have a status change during the study period and have reopened
+            during the study period.
+        -   These mines can follow these patterns:
+            -   abandoned - reopen - abandoned
+                -   mine emissions are calculated with the period of reopen removed in
+                    the calculation.
+            -   open - abandonded - repoen
+    """
 
     # %%
     result_list = []
-    # for each year we have mine data, calculate emissions based on the basin, mine
-    # status, and the number of years closed.
-    reopened_mine_list = []
-    aban_mine_list = []
-    for year in range(min_year, max_year + 1):
 
+    core_mines_df = always_abandoned_mines_df.copy()
+    processing_mines_df = has_status_change_df.copy()
+
+    print(f"starting with {len(core_mines_df)} core mines...")
+    print(f"{len(processing_mines_df)} open/close during time...")
+    print()
+    for year in range(min_year, max_year + 1):
+        # if year == 2014:
+        #     break
+        print("=" * 50)
+        print(f"Processing year: {year}")
+        print("=" * 50)
         # get the normalized ratios of mine status by year
         yearly_ratios_normed_df = ratios_normed_df.loc[year].droplevel(-1)
 
@@ -557,69 +650,92 @@ def task_get_abd_coal_proxy_data(
         # We can calculate the actual fraction of emissions for a given year.
         calc_date = datetime.datetime(year=year, month=12, day=31)
 
-        # get the mines that are abandoned this year or earlier of any date
-        year_aban_df = always_abandoned_mines_df
-        # remove the mines that have reopened prior to this year
-        year_aban_df = year_aban_df[~year_aban_df.MINE_ID.isin(reopened_mine_list)]
-
-        # FOR REFERENCE: mines that were abandoned this year
-        aban_this_year_df = year_aban_df.query("date_abd.dt.year == @calc_date.year")
-
-        # FOR REFERENCE: abandoned mines that were reopened this year
-        reopen_this_year_df = abandoned_mines_df.query(
-            "(reopen_date.dt.year == @calc_date.year)"
-        )
-
-        reopened_mine_list.extend(reopen_this_year_df.MINE_ID.to_list())
-        aban_mine_list.extend(aban_this_year_df.MINE_ID.to_list())
-
-        print(f"total mines abandoned {year}: {len(year_aban_df)}")
-        print(f"mines abandoned in this year {year}: {len(aban_this_year_df)}")
-        print(
-            f"mines abandoned reporting reopen this year {year}: "
-            f"{len(reopen_this_year_df)}"
-        )
-
-        # combine the abandoned and newly reopened mines for this year
-        year_mines_df = pd.concat([year_aban_df]).assign(
+        # get the mines that are always abandoned and have not changed status
+        # calculate emissions
+        year_aban_df = core_mines_df.copy().assign(
             # assign the current year for calculations
             year=year,
             days_closed=lambda df: (calc_date - df["date_abd"]),
-            # days_closed=lambda df: np.where(
-            #     df["date_abd"].dt.year == year,
-            #     -((calc_date - df["date_abd"]) / 2),
-            #     calc_date - df["date_abd"],
-            # ),
             # calculate the number of years closed
             years_closed=lambda df: (df["days_closed"].dt.days / year_days),
             # create an empty column to hold the results
             mine_emi=0,
         )
 
-        # these are mines that are listed as active, but were reopened this year
-        # so we take these mines and calculate the days closed as the difference
-        # of days from when it when it was abandoned to the day it reopened this year.
-        # if the mine was opened this year, we subtract out the number of days it was
-        # operational from the days closed
-        year_active_mines_df = active_mines_df.query(
-            "(date_abd < @calc_date) & (reopen_date.dt.year >= @calc_date.year)"
+        change_this_year_query = (
+            "((date_abd.dt.year == @calc_date.year)"
+            "| (reopen_date.dt.year == @calc_date.year))"
+        )
+        # these mines change status at some point, but are currently open and are
+        # not changing this year.
+        open_right_now_df = processing_mines_df.query(
+            f"(gepa_status == 'open') & ~{change_this_year_query}"
+        )
+        # these mines change status at some point, but are currently closed and are
+        # not changing this year.
+        closed_right_now_df = processing_mines_df.query(
+            f"(gepa_status == 'abandoned') & ~{change_this_year_query}"
         ).assign(
+            # assign the current year for calculations
             year=year,
-            operating_days=lambda df: np.where(
-                df["reopen_date"].dt.year.eq(year),
-                (calc_date - df["reopen_date"]).dt.days,
-                0,
-            ),
-            days_closed=lambda df: (calc_date - df["date_abd"]).dt.days
-            - df["operating_days"],
-            years_closed=lambda df: df["days_closed"] / year_days,
+            days_closed=lambda df: (calc_date - df["date_abd"]),
+            # calculate the number of years closed
+            years_closed=lambda df: (df["days_closed"].dt.days / year_days),
+            # create an empty column to hold the results
+            mine_emi=0,
+        )
+        # get the mines that change status this year.
+        change_this_year_df = processing_mines_df.query(change_this_year_query)
+
+        # if a mine is abandoned this year, we will calculate the emissions based on
+        # the date of abandonment up to the end of the year.
+        aban_this_year_df = change_this_year_df.query(
+            "(date_abd.dt.year == @calc_date.year)"
+        ).assign(
+            # assign the current year for calculations
+            year=year,
+            days_closed=lambda df: (calc_date - df["date_abd"]),
+            # calculate the number of years closed
+            years_closed=lambda df: (df["days_closed"].dt.days / year_days),
             # create an empty column to hold the results
             mine_emi=0,
         )
 
+        # if a mine is reopened this year, we will calculate the emissions based on
+        # the date of abandonment up to the date of reopen. NOTE: this is different than
+        # the other mines.
+        reopen_this_year_df = change_this_year_df.query(
+            "(reopen_date.dt.year == @calc_date.year)"
+        ).assign(
+            # assign the current year for calculations
+            year=year,
+            days_closed=lambda df: (df["reopen_date"] - df["date_abd"]),
+            # calculate the number of years closed
+            years_closed=lambda df: (df["days_closed"].dt.days / year_days),
+            # create an empty column to hold the results
+            mine_emi=0,
+        )
+
+        sum_check = (
+            len(closed_right_now_df)
+            + len(aban_this_year_df)
+            + len(reopen_this_year_df)
+            + len(open_right_now_df)
+        ) == len(processing_mines_df)
+        # print(f"total mines abandoned {year}: {len(year_aban_df)}")
+        print(f"mines closed:                         {len(closed_right_now_df)}")
+        print(f"mines open:                           {len(open_right_now_df)}")
+        print(f"mines abandoned:                      {len(aban_this_year_df)}")
+        print(f"mines reopen:                         {len(reopen_this_year_df)}")
+        print(f"do the numbers add up?                {sum_check}")
+        print("-" * 50)
+
         # combine the abandoned and newly reopened mines for this year
-        # EEM: where is year_abandoned_mines_df defined? This doesn't seem to appear anywhere else in the file
-        year_mines_df = pd.concat([year_mines_df, year_active_mines_df])
+        year_mines_df = pd.concat(
+            [year_aban_df, closed_right_now_df, aban_this_year_df, reopen_this_year_df]
+        )
+
+        print(f"total mines:                          {len(year_mines_df)}")
 
         # we now calculate the emissions for each mine based on the status of the mine
         # and the basin it is in.
@@ -645,6 +761,16 @@ def task_get_abd_coal_proxy_data(
         # mines that are recovering are assigned 0 emissions
         res_df.loc[res_df["recovering"].eq(1), "mine_emi"] = 0
         result_list.append(res_df)
+
+        # update the status of mines that changed this year.
+        processing_mines_df.loc[
+            processing_mines_df["date_abd"].dt.year == year, "gepa_status"
+        ] = "abandoned"
+
+        processing_mines_df.loc[
+            processing_mines_df["reopen_date"].dt.year == year, "gepa_status"
+        ] = "open"
+
         print()
 
     result_df = pd.concat(result_list, ignore_index=True)
@@ -660,25 +786,7 @@ def task_get_abd_coal_proxy_data(
         raise ValueError("Recovering mines should have 0 emissions")
 
     # %%
-    reopened_mines_df = all_mines_df[all_mines_df.MINE_ID.isin(reopened_mine_list)]
-    count_reopened_mines = len(reopened_mines_df)
-    print(
-        f"there are {count_reopened_mines} mines that were reopened during the "
-        "time period:"
-    )
-    reopened_mines_df.sort_values("reopen_date")
-    # %%
-    aban_mines_df = all_mines_df[all_mines_df.MINE_ID.isin(aban_mine_list)]
-    count_aban_mines = len(aban_mines_df)
-    print(
-        f"there are {count_aban_mines} mines that were abandoned during the "
-        "time period:"
-    )
-    aban_mines_df.sort_values("date_abd")
 
-    # %%
-
-    # %%
     # some visuals to check the data
     sns.relplot(data=result_df, y="mine_emi", x="year", hue="state_code", kind="line")
     # sns.relplot(data=result_df, y="mine_emi", x="year", kind="line")

--- a/gch4i/proxy_processing/task_abandoned_coal_proxy.py
+++ b/gch4i/proxy_processing/task_abandoned_coal_proxy.py
@@ -430,7 +430,6 @@ def task_get_abd_coal_proxy_data(
     # emissions calculations.
 
     all_mines_df.sort_values("reopen_date", ascending=False)
-    # %%
 
     # %%
     # # actives mines are those that are listed as active and have a reopen date before
@@ -560,6 +559,14 @@ def task_get_abd_coal_proxy_data(
     open_aban_open_df = has_2_status_change_df.query("reopen_date > date_abd")
     aban_open_aban_df = has_2_status_change_df.query("reopen_date <= date_abd")
 
+    prepped_2_status_df = has_2_status_change_df.assign(
+        reopen_date=np.nan,
+        gepa_status=lambda df: np.where(
+            datetime.datetime(year=2012, month=12, day=31) < df["date_abd"], "open", "abandoned"
+        ),
+    )
+
+
     # reference_mines_df = reference_mines_df.drop(index=has_status_change_df.index)
     # has_status_change_df.sort_values("date_abd")
     status_change_count_check = (
@@ -594,32 +601,42 @@ def task_get_abd_coal_proxy_data(
     # %%
     """
     Here we are now holding the following dataframes for processing:
-    -   always_abandoned_mines_df:
-        -   mines that were abandoned prior to the study period and have not reopened.
-        -   These are assumed to be abandoned and we calculate emissions based on the
-            date of abandonment regardless of the reopen date.
-    - reopens_during_study_df:
-        -   mines that have reopened during the study period. These mines will be
-            calculated based on the date of abandonment up to the date of reopen.
-    - closes_during_study_df:
-        -   mines that have closed during the study period. These mines will be be added
-            to the abandoned mines list and calculated based on the date of abandonment.
-    - has_2_status_change_df:
-        -   mines that have a status change during the study period and have reopened
-            during the study period.
-        -   These mines can follow these patterns:
-            -   abandoned - reopen - abandoned
-                -   mine emissions are calculated with the period of reopen removed in
-                    the calculation.
-            -   open - abandonded - repoen
+    -   core_mines_df
+        -   always_abandoned_mines_df:
+            -   mines that were abandoned prior to the study period and have not reopened.
+            -   These are assumed to be abandoned and we calculate emissions based on the
+                date of abandonment regardless of the reopen date.
+    -   processing_mines_df == has_status_change_df + has_2_status_change_df
+        - reopens_during_study_df:
+            -   mines that have reopened during the study period. These mines will be
+                calculated based on the date of abandonment up to the date of reopen.
+        - closes_during_study_df:
+            -   mines that have closed during the study period. These mines will be be added
+                to the abandoned mines list and calculated based on the date of abandonment.
+        - has_2_status_change_df:
+            -   Since we have to make some assumptions about the time that any of these
+                mines were abandoned, we will calculate the emissions based on the date of
+                abandonment only, ignoring the reopen date.
+            -   mines that have a status change during the study period and have reopened
+                during the study period.
+            -   These mines can follow these patterns:
+                -   abandoned - reopen - abandoned
+                    -   mine emissions are calculated with the period of reopen removed in
+                        the calculation.
+                -   open - abandonded - repoen
     """
 
     # %%
     result_list = []
 
     core_mines_df = always_abandoned_mines_df.copy()
-    processing_mines_df = has_status_change_df.copy()
-
+    # for the mines with 2 status changes, we are going to remove the reopen date so
+    # that we are only using the date of abandonment for the calculations.
+    # NOTE: we can ignore the FutreWarning here. It does not like setting the col as
+    # np.nan, but we are doing this to remove the reopen date from the calculations.
+    processing_mines_df = pd.concat(
+        [has_status_change_df, prepped_2_status_df]
+    ).copy()
     print(f"starting with {len(core_mines_df)} core mines...")
     print(f"{len(processing_mines_df)} open/close during time...")
     print()
@@ -639,11 +656,6 @@ def task_get_abd_coal_proxy_data(
             .all()
         ):
             raise ValueError("Ratios do not sum to 1")
-
-        # EEM: is the code below legacy from v2? If so, please delete
-        # The logic here was that this date would be representative of the mean emission rate for that year (since we are dealing with exponential decay rates)
-        # the same logic was behind why we divided the number of closed days by 2.
-        # I think that if we treat all mines in the same way, it should still be ok to use the entire year
 
         # this year date to calc relative emissions
         # NOTE: this is different from the v2 notebook where the date was 07/02
@@ -835,6 +847,5 @@ def task_get_abd_coal_proxy_data(
     # %%
     # save the final proxy data
     proxy_gdf.to_parquet(output_path)
-
 
 # %%


### PR DESCRIPTION
This should now include handling of mines that change status during the study period, with the decision made to only use the abandoned status change for mines that change their status twice during the inventory period.