### PR TITLE
Flooded_lands

### DIFF
--- a/gch4i/emis_processing/task_flooded_lands_emi.py
+++ b/gch4i/emis_processing/task_flooded_lands_emi.py
@@ -1,7 +1,7 @@
 """
 Name:                   task_wetlands_rem_wet_emi.py
-Date Last Modified:     2025-01-30
-Authors Name:           Andrew Burnette (RTI International)
+Date Last Modified:     2025-06-13
+Authors Name:           Andrew Burnette, Nick Kruskamp (RTI International)
 Purpose:                Mapping of wetlands remaining wetlands emissions to State, Year,
                             emissions format
 gch4i_name:             4D1_wetlands_remaining_wetlands
@@ -15,6 +15,7 @@ Emis/Output Files:      - {emi_data_dir_path}/
                             peatlands_emi.csv
                             rem_coastal_wetlands_emi.csv
 """
+
 # %% STEP 0. Load packages, configuration files, and local parameters ------------------
 from pathlib import Path
 from typing import Annotated
@@ -28,14 +29,14 @@ from gch4i.config import (
     emi_data_dir_path,
     ghgi_data_dir_path,
     max_year,
-    min_year
+    min_year,
 )
 from gch4i.utils import tg_to_kt
 
 # %% Step 1. Create Function
 
 
-def get_wetlands_rem_wet_inv_data(in_path, src, params):
+def get_wetlands_rem_wet_inv_data(in_path, params):
     """read in the ch4_kt values for each state
     User is required to specify the subcategory of interest:
     - Flooded Land Remaining Flooded Land: Reservoir
@@ -47,8 +48,6 @@ def get_wetlands_rem_wet_inv_data(in_path, src, params):
     ----------
     in_path : str
         path to the input file
-    src : str
-        subcategory of interest
     params : dict
         additional parameters
     """
@@ -58,14 +57,18 @@ def get_wetlands_rem_wet_inv_data(in_path, src, params):
         in_path,
         sheet_name=params["arguments"][0],  # Sheet name
         skiprows=params["arguments"][1],  # Skip rows
-        )
+    )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
     # Create state_list to filter states
     state_list = emi_df["GeoRef"].unique().tolist()
-    state_list = [state for state in state_list if state not in ["AS", "GU", "MP", "PR",
-                                                                 "VI", "AK", "HI",
-                                                                 "National"]]
+    state_list = [
+        state
+        for state in state_list
+        if state not in ["AS", "GU", "MP", "PR", "VI", "AK", "HI", "National"]
+    ]
+
+    cat, subcat_1, subcat_2 = params['substrings']
 
     # Clean and format the data
     emi_df = (
@@ -81,9 +84,13 @@ def get_wetlands_rem_wet_inv_data(in_path, src, params):
         # Query for states in state_list
         .query("state_code in @state_list")
         # Query for CH4 emissions and the source of interest
-        .query(f"(ghg == 'CH4') & (ghgi_source == '{src}')")
+        .query(f"(ghg == 'CH4')")
         # Query for the subcategory combinations needed
-        .query(f"(category == '{params['substrings'][0]}') & (subcategory1 == '{params['substrings'][1]}') & (subcategory2.isin({params['substrings'][2]}))", engine="python")
+        .query(
+            f"(category == '{cat}')"
+            f"& (subcategory1 == '{subcat_1}')"
+            # f"& (subcategory2.isin({subcat_2}))",
+        )
         # Filter state code and years
         .filter(items=["state_code"] + year_list, axis=1)
         .set_index("state_code")
@@ -106,7 +113,9 @@ def get_wetlands_rem_wet_inv_data(in_path, src, params):
         .groupby(["state_code", "year"])["ghgi_ch4_kt"]
         .sum()
         .reset_index()
-        )
+    )
+    emi_df
+
     return emi_df
 
 
@@ -118,60 +127,60 @@ emi_parameters_dict.
 The parameters are read from the emi_proxy_mapping sheet of the gch4i_data_guide_v3.xlsx
 file. The parameters are used to create the pytask task for the emi.
 """
-# gch4i_name in gch4i_data_guide_v3.xlsx, emi_proxy_mapping sheet
-source_name = "4D1_wetlands_remaining_wetlands"
-# Directory name for GHGI data
-source_path = "4D1_wetlands_remaining_wetlands"
+# %% STEP 2. Initialize Parameters
+"""
+This section initializes the parameters for the task and stores them in the
+emi_parameters_dict.
 
+The parameters are read from the emi_proxy_mapping sheet of the gch4i_data_guide_v3.xlsx
+file. The parameters are used to create the pytask task for the emi.
+"""
+# gch4i_name in gch4i_data_guide_v3.xlsx, emi_proxy_mapping sheet
+source_name_1 = "4D1_wetlands_remaining_wetlands"
+source_name_2 = "4D2_land_converted_to_wetlands"
 # Data Guide Directory
 proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
 # Read and query for the source name (ghch4i_name)
 proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
-    f"gch4i_name == '{source_name}'"
+    f"(gch4i_name == '{source_name_1}') | (gch4i_name == '{source_name_2}')"
 )
 
 # Initialize the emi_parameters_dict
 emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
+    print(data)
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
-        "source_list": [x.strip().casefold() for x in data.gch4i_source.to_list()],
+        "input_path": ghgi_data_dir_path
+        / data.gch4i_name.values[0]
+        / data.file_name.values[0],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": emi_data_dir_path / f"{emi_name}.csv",
     }
 
 emi_parameters_dict
-
-
 # %% STEP 3. Create Pytask Function and Loop
 
-for _id, _kwargs in emi_parameters_dict.items():
+def task_flooded_lands_emis(
+    input_path: Path,
+    parameters: dict,
+    output_path: Annotated[Path, Product],
+) -> None:
 
-    @mark.persist
-    @task(id=_id, kwargs=_kwargs)
-    def task_wetlands_rem_wetlands_emi(
-        input_paths: list[Path],
-        source_list: list[str],
-        parameters: dict,
-        output_path: Annotated[Path, Product],
-    ) -> None:
+    emi_df = get_wetlands_rem_wet_inv_data(input_path, parameters)
+    # Save the emissions data to the output path
+    emi_df.to_csv(output_path)
 
-        # Initialize the emi_df_list
-        emi_df_list = []
-        # Loop through the input paths and source list to get the emissions data
-        for input_path, ghgi_group in zip(input_paths, source_list):
-            individual_emi_df = get_wetlands_rem_wet_inv_data(input_path,
-                                                              ghgi_group,
-                                                              parameters)
-            emi_df_list.append(individual_emi_df)
 
-        # Concatenate the emissions data and group by state and year
-        emission_group_df = (
-            pd.concat(emi_df_list)
-            .groupby(["state_code", "year"])["ghgi_ch4_kt"]
-            .sum()
-            .reset_index()
-        )
-        # Save the emissions data to the output path
-        emission_group_df.to_csv(output_path)
+# %%
+import pytask
+
+sesh = pytask.build(
+    tasks=[
+        task_flooded_lands_emis(**kwargs)
+        for _id, kwargs in emi_parameters_dict.items()
+    ]
+)
+sesh
+
+# %%

--- a/gch4i/proxy_processing/task_flooded_lands.py
+++ b/gch4i/proxy_processing/task_flooded_lands.py
@@ -13,8 +13,9 @@ from pathlib import Path
 from typing import Annotated
 
 import geopandas as gpd
+import pytask
 import rasterio
-from pytask import Product, mark, task
+from pytask import Product
 
 from gch4i.config import (
     EQ_AREA_CRS,
@@ -35,20 +36,23 @@ from gch4i.utils import (
 fl_data_path = sector_data_dir_path / "flooded_lands"
 intermediate_dir = fl_data_path / "intermediate"
 intermediate_dir.mkdir(exist_ok=True, parents=True)
-# list(fl_data_path.rglob("*"))
-
 fl_gpkg_path = fl_data_path / "flooded_lands_.gpkg"
 
 query_dict = dict(
-    fl_rem_res="lu == 'Flooded Land Remaining Flooded Land' & type == 'reservoir'",
-    fl_rem_other="lu == 'Flooded Land Remaining Flooded Land' & type == 'other constructed waterbodies'",  # noqa
+    fl_rem_res=("lu == 'Flooded Land Remaining Flooded Land' & type == 'reservoir'"),
+    fl_rem_other=(
+        "lu == 'Flooded Land Remaining Flooded Land' "
+        "& type == 'other constructed waterbodies'"
+    ),  # noqa
     fl_conv_res="lu == 'Land Converted to Flooded Land' & type == 'reservoir'",
+    fl_conv_other=(
+        "lu == 'Land Converted to Flooded Land' "
+        "& type == 'other constructed waterbodies'"
+    ),
 )
 
 # %%
 EMTPY_GRID_GDF = get_cell_gdf().to_crs(EQ_AREA_CRS)
-EMTPY_GRID_GDF
-
 
 # %%
 
@@ -63,90 +67,19 @@ def get_data_params(years, q_dict):
         if the_year > 2020:
             continue
 
-        arg_dict[the_year] = dict()
-        arg_dict[the_year]["the_year"] = the_year
-        arg_dict[the_year]["input_path"] = fl_gpkg_path
-        arg_dict[the_year]["query_dict"] = q_dict
+        arg_dict[str(the_year)] = dict()
+        arg_dict[str(the_year)]["the_year"] = the_year
+        arg_dict[str(the_year)]["input_path"] = fl_gpkg_path
+        arg_dict[str(the_year)]["query_dict"] = q_dict
 
         output_paths = {
             x: intermediate_dir / f"{x}_{the_year}.tif" for x in q_dict.keys()
         }
 
-        arg_dict[the_year]["output_path_dict"] = output_paths
+        arg_dict[str(the_year)]["output_path_dict"] = output_paths
     return arg_dict
 
 
-_ID_TO_KWARGS_FL_DATA = get_data_params(years, query_dict)
-
-for _id, kwargs in _ID_TO_KWARGS_FL_DATA.items():
-
-    @mark.persist
-    @task(id=_id, kwargs=kwargs)
-    def task_process_fl_data(
-        the_year: int,
-        input_path: Path,
-        query_dict: dict,
-        output_path_dict: Annotated[dict[str, Path], Product],
-    ) -> None:
-
-        profile = GEPA_spatial_profile()
-        profile.profile.update(count=1)
-
-        year_gdf = gpd.read_file(input_path, layer=str(the_year))
-
-        # for each of the flooded land types we need
-        for key, query in query_dict.items():
-
-            # create the output path
-            out_path = output_path_dict[key]
-            # pytask will run this even if the data exist for just one product, so we're
-            # going to skip if the file exists here to avoid unnecessary processing.
-            if out_path.exists():
-                continue
-            # filter the data from that year with with query, calculate the area of the
-            # flooded land polygons
-            print(f"filtering for {key} in {the_year}")
-            data_gdf = (
-                year_gdf.query(query)
-                .to_crs(EQ_AREA_CRS)
-                .assign(fl_area=lambda df: df.area)
-            )
-            print(the_year, key, data_gdf.shape[0])
-            # data_gdf.to_parquet(out_path)
-
-            # the bulk of the work: overlay the data with the grid cells, calculated the
-            # fractional area of that cell that is flooded, and multiply that by the
-            # total ch4 emissions for that cell to get the fraction of emission. This
-            # accounts for polygons that span multiple cells so that the emissions are
-            # allocated via the fractional area. Then groupby the cell id and sum the
-            # emissions.
-            print(f"calculating grid cell emissions for {key} in {the_year}")
-            ch4_sum = (
-                data_gdf.overlay(
-                    EMTPY_GRID_GDF.reset_index(drop=False), how="intersection"
-                )
-                .assign(
-                    fractional_area=lambda df: df.area / df["fl_area"],
-                    frac_emi=lambda df: df["fractional_area"]
-                    * df["ch4.total.tonnes.y"],
-                )
-                .groupby("index")["frac_emi"]
-                .sum()
-                .rename("ch4_sum")
-            )
-            # join this data back to the empty grid, reshape the data to the original
-            # grid.
-            res_gdf = EMTPY_GRID_GDF.join(ch4_sum)
-
-            print(f"saving data for {key} in {the_year}")
-            out_arr = res_gdf.ch4_sum.values.reshape(profile.arr_shape)
-            # save the file
-            with rasterio.open(out_path, "w", **profile.profile) as dst:
-                dst.write(out_arr, 1)
-            print()
-
-
-# %%
 def get_stack_params(years, q_dict):
     arg_dict = {}
     for key in q_dict.keys():
@@ -165,19 +98,6 @@ def get_stack_params(years, q_dict):
     return arg_dict
 
 
-_ID_TO_KWARGS_STACK = get_stack_params(years, query_dict)
-
-for _id, kwargs in _ID_TO_KWARGS_STACK.items():
-
-    @mark.persist
-    @task(id=_id, kwargs=kwargs)
-    def task_stack_fl_data(input_paths: Path, output_path: Annotated[Path, Product]):
-        stack_rasters(input_paths, output_path)
-
-
-# %%
-
-
 def get_proxy_params(q_dict):
     arg_dict = dict()
     for key in q_dict.keys():
@@ -189,18 +109,103 @@ def get_proxy_params(q_dict):
     return arg_dict
 
 
+def task_process_fl_data(
+    the_year: int,
+    input_path: Path,
+    query_dict: dict,
+    output_path_dict: Annotated[dict[str, Path], Product],
+) -> None:
+
+    profile = GEPA_spatial_profile()
+    profile.profile.update(count=1)
+
+    year_gdf = gpd.read_file(input_path, layer=str(the_year))
+
+    # for each of the flooded land types we need
+    for key, query in query_dict.items():
+
+        # create the output path
+        out_path = output_path_dict[key]
+        # pytask will run this even if the data exist for just one product, so we're
+        # going to skip if the file exists here to avoid unnecessary processing.
+        if out_path.exists():
+            continue
+        # filter the data from that year with with query, calculate the area of the
+        # flooded land polygons
+        print(f"filtering for {key} in {the_year}")
+        data_gdf = (
+            year_gdf.query(query).to_crs(EQ_AREA_CRS).assign(fl_area=lambda df: df.area)
+        )
+        print(the_year, key, data_gdf.shape[0])
+        # data_gdf.to_parquet(out_path)
+
+        # the bulk of the work: overlay the data with the grid cells, calculated the
+        # fractional area of that cell that is flooded, and multiply that by the
+        # total ch4 emissions for that cell to get the fraction of emission. This
+        # accounts for polygons that span multiple cells so that the emissions are
+        # allocated via the fractional area. Then groupby the cell id and sum the
+        # emissions.
+        print(f"calculating grid cell emissions for {key} in {the_year}")
+        ch4_sum = (
+            data_gdf.overlay(EMTPY_GRID_GDF.reset_index(drop=False), how="intersection")
+            .assign(
+                fractional_area=lambda df: df.area / df["fl_area"],
+                frac_emi=lambda df: df["fractional_area"] * df["ch4.total.tonnes.y"],
+            )
+            .groupby("index")["frac_emi"]
+            .sum()
+            .rename("ch4_sum")
+        )
+        # join this data back to the empty grid, reshape the data to the original
+        # grid.
+        res_gdf = EMTPY_GRID_GDF.join(ch4_sum)
+
+        print(f"saving data for {key} in {the_year}")
+        out_arr = res_gdf.ch4_sum.values.reshape(profile.arr_shape)
+        # save the file
+        with rasterio.open(out_path, "w", **profile.profile) as dst:
+            dst.write(out_arr, 1)
+        print()
+
+
+def task_stack_fl_data(input_paths: list[Path], output_path: Annotated[Path, Product]):
+    stack_rasters(
+        input_paths=input_paths,
+        output_path=output_path,
+    )
+
+
+def task_fl_proxy(
+    input_path: Path,
+    state_geo_path: Path,
+    output_path: Annotated[Path, Product],
+) -> None:
+    proxy_from_stack(input_path, state_geo_path, output_path)
+
+
+# %%
+
+_ID_TO_KWARGS_FL_DATA = get_data_params(years, query_dict)
+
+_ID_TO_KWARGS_STACK = get_stack_params(years, query_dict)
+
 _ID_PROXY_PARAMS = get_proxy_params(query_dict)
 
-for _id, kwargs in _ID_PROXY_PARAMS.items():
 
-    @mark.persist
-    @task(id=_id, kwargs=kwargs)
-    def task_fl_proxy(
-        input_path: Path,
-        state_geo_path: Path,
-        output_path: Annotated[Path, Product],
-    ) -> None:
-        proxy_from_stack(input_path, state_geo_path, output_path)
+# %%
+
+
+pytask_sesh = pytask.Session(
+    tasks=[
+        task_process_fl_data(**kwargs) for _id, kwargs in _ID_TO_KWARGS_FL_DATA.items()
+    ]
+)
+pytask_sesh = pytask.Session(
+    tasks=[task_stack_fl_data(**kwargs) for _id, kwargs in _ID_TO_KWARGS_STACK.items()]
+)
+pytask_sesh = pytask.Session(
+    tasks=[task_fl_proxy(**kwargs) for _id, kwargs in _ID_PROXY_PARAMS.items()]
+)
 
 
 # %%

--- a/gch4i/proxy_processing/task_flooded_lands.py
+++ b/gch4i/proxy_processing/task_flooded_lands.py
@@ -95,7 +95,7 @@ def get_stack_params(years, q_dict):
         for the_year in years:
             # if the the year is 2021 or 2022, use 2020 data
                 
-            if the_year > 2020:
+            if the_year >= 2020:
                 # NOTE: for flooded land coverted other, the 2020 data are missing a
                 # state (ME), so instead of replicating 2020 into 2021 and 2022, we use
                 # the 2019 data, which is the last year that has data for all states.

--- a/gch4i/proxy_processing/task_flooded_lands.py
+++ b/gch4i/proxy_processing/task_flooded_lands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Annotated
 
 import geopandas as gpd
+import numpy as np
 import pytask
 import rasterio
 from pytask import Product
@@ -29,6 +30,7 @@ from gch4i.utils import (
     get_cell_gdf,
     proxy_from_stack,
     stack_rasters,
+    normalize,
 )
 
 # %%
@@ -37,6 +39,11 @@ fl_data_path = sector_data_dir_path / "flooded_lands"
 intermediate_dir = fl_data_path / "intermediate"
 intermediate_dir.mkdir(exist_ok=True, parents=True)
 fl_gpkg_path = fl_data_path / "flooded_lands_.gpkg"
+
+
+# NOTE: I organize the proxy creation for these tasks to reduce the runtime. The wetland
+# data are huge, so I/O is the biggest bottleneck. By organizing the tasks this way, we
+# can avoid reading the same data multiple times.
 
 query_dict = dict(
     fl_rem_res=("lu == 'Flooded Land Remaining Flooded Land' & type == 'reservoir'"),
@@ -145,23 +152,41 @@ def task_process_fl_data(
         # accounts for polygons that span multiple cells so that the emissions are
         # allocated via the fractional area. Then groupby the cell id and sum the
         # emissions.
-        print(f"calculating grid cell emissions for {key} in {the_year}")
         ch4_sum = (
             data_gdf.overlay(EMTPY_GRID_GDF.reset_index(drop=False), how="intersection")
+            .loc[:, ["index", "fl_area", "ch4.total.tonnes.y", "geometry"]]
             .assign(
                 fractional_area=lambda df: df.area / df["fl_area"],
-                frac_emi=lambda df: df["fractional_area"] * df["ch4.total.tonnes.y"],
+                flooded_emi=lambda df: df["fractional_area"] * df["ch4.total.tonnes.y"],
+                flooded_area=lambda df: df["fractional_area"] * df["fl_area"],
             )
-            .groupby("index")["frac_emi"]
-            .sum()
-            .rename("ch4_sum")
+            .drop(columns=["ch4.total.tonnes.y", "fractional_area", "fl_area"])
+            .dissolve("index", aggfunc="sum")
         )
-        # join this data back to the empty grid, reshape the data to the original
-        # grid.
-        res_gdf = EMTPY_GRID_GDF.join(ch4_sum)
+        ch4_sum_gdf = (
+            EMTPY_GRID_GDF.join(ch4_sum.drop(columns="geometry"))
+            # .assign(centroid=lambda df: df.geometry.centroid)
+            # .set_geometry("centroid")
+            # .sjoin(state_gdf[["state_code", "geometry"]], how="left")
+            # .set_geometry("geometry")
+            # .drop(columns=["centroid", "index_right"])
+        )
+
+        grid_sum_check = np.isclose(
+            ch4_sum_gdf["flooded_emi"].sum(),
+            data_gdf["ch4.total.tonnes.y"].sum(),
+            atol=0,
+            rtol=0.01,
+        )
+        if not grid_sum_check:
+            raise ValueError(
+                f"Grid sum check failed for {key} in {the_year}. "
+                f"Grid sum: {ch4_sum_gdf['flooded_emi'].sum()}, "
+                f"Data sum: {data_gdf['ch4.total.tonnes.y'].sum()}"
+            )
 
         print(f"saving data for {key} in {the_year}")
-        out_arr = res_gdf.ch4_sum.values.reshape(profile.arr_shape)
+        out_arr = ch4_sum_gdf.flooded_emi.values.reshape(profile.arr_shape)
         # save the file
         with rasterio.open(out_path, "w", **profile.profile) as dst:
             dst.write(out_arr, 1)
@@ -195,16 +220,12 @@ _ID_PROXY_PARAMS = get_proxy_params(query_dict)
 # %%
 
 
-pytask_sesh = pytask.Session(
+pytask_sesh = pytask.build(
     tasks=[
         task_process_fl_data(**kwargs) for _id, kwargs in _ID_TO_KWARGS_FL_DATA.items()
     ]
-)
-pytask_sesh = pytask.Session(
-    tasks=[task_stack_fl_data(**kwargs) for _id, kwargs in _ID_TO_KWARGS_STACK.items()]
-)
-pytask_sesh = pytask.Session(
-    tasks=[task_fl_proxy(**kwargs) for _id, kwargs in _ID_PROXY_PARAMS.items()]
+    + [task_stack_fl_data(**kwargs) for _id, kwargs in _ID_TO_KWARGS_STACK.items()]
+    + [task_fl_proxy(**kwargs) for _id, kwargs in _ID_PROXY_PARAMS.items()]
 )
 
 

--- a/gch4i/proxy_processing/task_flooded_lands.py
+++ b/gch4i/proxy_processing/task_flooded_lands.py
@@ -94,8 +94,16 @@ def get_stack_params(years, q_dict):
         input_paths = []
         for the_year in years:
             # if the the year is 2021 or 2022, use 2020 data
+                
             if the_year > 2020:
-                input_paths.append(intermediate_dir / f"{key}_2020.tif")
+                # NOTE: for flooded land coverted other, the 2020 data are missing a
+                # state (ME), so instead of replicating 2020 into 2021 and 2022, we use
+                # the 2019 data, which is the last year that has data for all states.
+                # we otherwise replicate 2020 into 2021 and 2022 for the other proxies.
+                if key == "fl_conv_other":
+                    input_paths.append(intermediate_dir / f"{key}_2019.tif")
+                else:
+                    input_paths.append(intermediate_dir / f"{key}_2020.tif")
             else:
                 input_paths.append(intermediate_dir / f"{key}_{the_year}.tif")
         arg_dict[f"{key}_stack"] = {

--- a/gch4i/utils.py
+++ b/gch4i/utils.py
@@ -5,6 +5,7 @@ import threading
 import time
 import warnings
 from pathlib import Path
+import re
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
@@ -431,10 +432,16 @@ def vector_to_gepa_grid():
 def stack_rasters(input_paths: list[Path], output_path: Path):
     profile = GEPA_spatial_profile().profile
     raster_list = []
-    years = [int(x.name.split("_")[2]) for x in input_paths]
+    years = []
+    year_pattern = re.compile(r'(\d{4})')
     for in_file in input_paths:
         if not in_file.exists():
             continue
+        match = year_pattern.search(in_file.name)
+        if match:
+            years.append(int(match.group(1)))
+        else:
+            years.append(None)
         with rasterio.open(in_file) as src:
             raster_list.append(src.read(1))
 


### PR DESCRIPTION
This addresses the missing emi/proxy pair for flooded lands:
- simplifies the emi process for all emi files in 4D1 and 4D2 and creates new proxy for conv_flooded_land_other_emi
- creates new fl_conv_other_proxy file
- as noted, slightly different process for fl_cov_other_proxy because the 2020 data are missing a state, but the supplemental process is more complicated here, so I have noted the change in the tracking sheet and will document after approval.