### PR TITLE
Update Config to project_dir_path. Update utils for v4_global. Update…

### DIFF
--- a/gch4i/config.py
+++ b/gch4i/config.py
@@ -7,25 +7,50 @@ load_dotenv(find_dotenv(usecwd=True), override=True)
 # Set path to location of input data files (same directory where output files are saved)
 # Define your own path to the data directory in the .env file
 # Remove the environment variable
-v3_data = os.getenv("V3_DATA_PATH")
-V3_DATA_PATH = Path(v3_data)
+project_dir_path = os.getenv("PROJECT_DIR_PATH")
+PROJECT_DIR_PATH = Path(project_dir_path)
+V3_DATA_PATH = Path(PROJECT_DIR_PATH) / "ghgi_v3_working/v3_data"
+V4_DATA_PATH = Path(PROJECT_DIR_PATH) / "gch4i_v4/v4_data"
 
-figures_data_dir_path = V3_DATA_PATH / "figures"
-global_data_dir_path = V3_DATA_PATH / "global"
-ghgi_data_dir_path = V3_DATA_PATH / "ghgi"
-tmp_data_dir_path = V3_DATA_PATH / "tmp"
-emi_data_dir_path = V3_DATA_PATH / "emis"
-proxy_data_dir_path = V3_DATA_PATH / "proxy"
-sector_data_dir_path = V3_DATA_PATH / "sector"
-intermediate_data_dir_path = V3_DATA_PATH / "interim"
+# V3 Paths
+v3_figures_data_dir_path = V3_DATA_PATH / "figures"
+v3_global_data_dir_path = V3_DATA_PATH / "global"
+v3_ghgi_data_dir_path = V3_DATA_PATH / "ghgi"
+v3_tmp_data_dir_path = V3_DATA_PATH / "tmp"
+v3_emi_data_dir_path = V3_DATA_PATH / "emis"
 
-prelim_gridded_dir = V3_DATA_PATH / "gridded_data_prelim"
-final_gridded_dir = V3_DATA_PATH / "gridded_data_final"
+v3_proxy_data_dir_path = V3_DATA_PATH / "proxy"
+v3_sector_data_dir_path = V3_DATA_PATH / "sector"
+v3_intermediate_data_dir_path = V3_DATA_PATH / "interim"
 
-logging_dir = V3_DATA_PATH.parents[0] / "gridding_log_and_qc"
-gridded_output_dir = logging_dir / "gridded_output"
+v3_prelim_gridded_dir = V3_DATA_PATH / "gridded_data_prelim"
+v3_final_gridded_dir = V3_DATA_PATH / "gridded_data_final"
 
-status_db_path = logging_dir / "gridding_status.db"
+v3_logging_dir = V3_DATA_PATH.parents[0] / "gridding_log_and_qc"
+v3_gridded_output_dir = v3_logging_dir / "gridded_output"
+
+v3_status_db_path = v3_logging_dir / "gridding_status.db"
+
+# V4 Paths
+# v4_figures_data_dir_path = V4_DATA_PATH / "figures"
+v4_global_data_dir_path = V4_DATA_PATH / "global"
+v4_ghgi_data_dir_path = V4_DATA_PATH / "ghgi"
+v4_tmp_data_dir_path = V4_DATA_PATH / "tmp"
+v4_emi_data_dir_path = V4_DATA_PATH / "emis"
+
+v4_proxy_data_dir_path = V4_DATA_PATH / "proxy"
+# v4_sector_data_dir_path = V4_DATA_PATH / "sector"
+v4_open_data_dir_path = V4_DATA_PATH / "open_data"
+v4_proprietary_data_dir_path = V4_DATA_PATH / "proprietary_data"
+
+v4_intermediate_data_dir_path = V4_DATA_PATH / "interim"
+v4_prelim_gridded_dir = V4_DATA_PATH / "gridded_data_prelim"
+v4_final_gridded_dir = V4_DATA_PATH / "gridded_data_final"
+
+# v4_logging_dir = V4_DATA_PATH.parents[0] / "gridding_log_and_qc"
+# v4_gridded_output_dir = v4_logging_dir / "gridded_output"
+
+# v4_status_db_path = v4_logging_dir / "gridding_status.db"
 
 # this is used by the file task_download_census_geo.py to download specific census
 # geometry files
@@ -33,7 +58,7 @@ census_geometry_list = ["county", "state", "primaryroads"]
 
 # the years of the data processing.
 min_year = 2012
-max_year = 2022
+max_year = 2023
 years = range(min_year, max_year + 1)
 
 EQ_AREA_CRS = "ESRI:102003"

--- a/gch4i/emis_processing/task_abandoned_coal_emis.py
+++ b/gch4i/emis_processing/task_abandoned_coal_emis.py
@@ -1,12 +1,12 @@
 """
 Name:                  Abandoned_Coal_Emissions
-Date Last Modified:    2024-09-19
+Date Last Modified:    2025-10-21
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized abandoned coal methane emissions data
 gch4i_name:             1B1a_abandoned_coal
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/1B1a_abandoned_coal/
-                            AbandonedCoalMines1990-2022_FRv1.xlsx
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/1B1a_abandoned_coal/
+                            AbandonedCoalMines1990-2023_FRv1.xlsx
 Output Files:          - {emi_data_dir_path}/abd_coal_emi.csv
 """
 
@@ -17,9 +17,9 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
@@ -44,10 +44,7 @@ def read_emi_data(in_path, src):
         # read in the data
         pd.read_excel(
             in_path,
-            sheet_name="InvDB",
-            skiprows=15,
-            # nrows=115,
-            # usecols="A:BA",
+            sheet_name="InvDB"
         )
         # name column names lower
         .rename(columns=lambda x: str(x).lower())
@@ -76,6 +73,8 @@ def read_emi_data(in_path, src):
         .apply(pd.to_numeric, errors="coerce")
         # # drop states that have all nan values
         .dropna(how="all")
+        # Fill missing with 0
+        .fillna(0)
         # reset the index state back to a column
         .reset_index()
         # make the table long by state/year
@@ -100,16 +99,16 @@ def read_emi_data(in_path, src):
 
 # Retrieve input data filepath from data guide sheet
 source_name = "1B1a_abandoned_coal"
-data_guide_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
-proxy_data = pd.read_excel(data_guide_path, sheet_name="emi_proxy_mapping").query(
+data_guide_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
+proxy_data = pd.read_excel(data_guide_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 emi_parameters_dict = {}
-for emi_name, data in proxy_data.groupby("emi"):
+for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_name / x for x in data.file_name],
-        "source_list": data.ghgi_group.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "input_paths": [v4_ghgi_data_dir_path / source_name / x for x in data.file_name],
+        "source_list": data.gch4i_source.to_list(),
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 # loop over input data files and process each using read_emi_data

--- a/gch4i/emis_processing/task_abandoned_og_wells_emi.py
+++ b/gch4i/emis_processing/task_abandoned_og_wells_emi.py
@@ -1,11 +1,11 @@
 """
 Name:                   task_abandoned_og_wells_emi.py
-Date Last Modified:     2025-06-10
+Date Last Modified:     2025-08-21
 Authors Name:           A. Burnette, Nick Kruskamp (RTI International)
 Purpose:                Mapping of wells emissions to State, Year, emissions format
 gch4i_name:             1B2ab_abandoned_og_wells
 Input Files:            - {ghgi_data_dir_path}/1B2ab_abandoned_og_wells/
-                            Abandoned_Wells_90-22_FR.xlsx
+                            Abandoned_Wells_90-23_FR.xlsx
 Output Files:           - {emi_data_dir_path}/
                             aog_gas_wells_emi.csv
                             aog_oil_wells_emi.csv
@@ -17,21 +17,21 @@ from typing import Annotated
 from pytask import Product, mark, task
 
 import pandas as pd
-import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
 from gch4i.utils import tg_to_kt
+#tg_to_kt = 1000
 
 # %% Step 1. Create Function
 
 
-def get_abandoned_og_wells_inv_data(in_path, src, params):
+def get_abandoned_og_wells_inv_data(in_path, src):
     """
     Change from previous years: no Plugged or Regional emis. All emissions are either
     from "gas" or "oil" wells.
@@ -45,16 +45,12 @@ def get_abandoned_og_wells_inv_data(in_path, src, params):
         path to the input file
     src : str
         subcategory of interest
-    params : dict
-        additional parameters
     """
 
     # Read in the data
     emi_df = pd.read_excel(
         in_path,
-        sheet_name=params["arguments"][0],  # sheet name
-        skiprows=params["arguments"][1],  # skip rows
-        nrows=params["arguments"][2],  # number of rows
+        sheet_name="InvDB"
     )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -109,9 +105,9 @@ file. The parameters are used to create the pytask task for the emi.
 source_name = "1B2ab_abandoned_og_wells"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -119,39 +115,43 @@ proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").quer
 emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
-    print(data)
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path / source_name / data.file_name.values[0],
-        "emi_source": data.Subcategory2.str.strip().str.casefold().values[0],
-        "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "input_paths": [v4_ghgi_data_dir_path / source_name / x for x in data.file_name],
+        "source_list": data.Subcategory2.str.strip().str.casefold().to_list(),
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 emi_parameters_dict
 # %% STEP 3. Create Pytask Function and Loop
 
+for _id, _kwargs in emi_parameters_dict.items():
 
-def task_abandoned_og_wells_emi(
-    input_path: Path,
-    emi_source: str,
-    parameters: dict,
-    output_path: Annotated[Path, Product],
-) -> None:
+    @mark.persist
+    @task(id=_id, kwargs=_kwargs)
+    def task_abandoned_og_wells_emi(
+        input_paths: list[Path],
+        source_list: list[str],
+        output_path: Annotated[Path, Product],
+    ) -> None:
 
-    emi_df = get_abandoned_og_wells_inv_data(input_path, emi_source, parameters)
-    # Save the emissions data to the output path
-    emi_df.to_csv(output_path)
+        source_list = [x.strip().casefold() for x in source_list]
 
+        # Initialize the emi_df_list
+        emi_df_list = []
+        # Loop through the input paths and source list to get the emissions data
+        for input_path, ghgi_group in zip(input_paths, source_list):
+            individual_emi_df = get_abandoned_og_wells_inv_data(
+                input_path,
+                ghgi_group
+                )
+            emi_df_list.append(individual_emi_df)
 
-# %%
-import pytask
-
-sesh = pytask.build(
-    tasks=[
-        task_abandoned_og_wells_emi(**kwargs)
-        for _id, kwargs in emi_parameters_dict.items()
-    ]
-)
-sesh
-
-# %%
+        # Concatenate the emissions data and group by state and year
+        emission_group_df = (
+            pd.concat(emi_df_list)
+            .groupby(["state_code", "year"])["ghgi_ch4_kt"]
+            .sum()
+            .reset_index()
+        )
+        # Save the emissions data to the output path
+        emission_group_df.to_csv(output_path)

--- a/gch4i/emis_processing/task_anaerobic_digestion_emi.py
+++ b/gch4i/emis_processing/task_anaerobic_digestion_emi.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_anaerobic_digestion_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of anaerobic_digestion emissions to State, Year,
                         emissions format
 gch4i_name:             5B2_anaerobic_digestion
 Input Files:            - {ghgi_data_dir_path}/5B2_anaerobic_digestion/
-                            State_AD_1990-2022_LA.xlsx
+                            State_AD_1990-2023_LA.xlsx
 Output Files:           - anaerobic_digestion_emi.csv
 """
 
@@ -19,9 +19,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -54,8 +54,8 @@ def get_anaerobic_dig_inv_data(in_path, src, params):
         pd.read_excel(
             in_path,
             sheet_name=params["arguments"][0],  # Sheet name
-            skiprows=params["arguments"][1],  # skip rows
-            nrows=params["arguments"][2],  # number of rows
+            #skiprows=params["arguments"][1],  # skip rows
+            #nrows=params["arguments"][2],  # number of rows
         )
     )
     # Specify years to keep
@@ -107,9 +107,9 @@ source_name = "5B2_anaerobic_digestion"
 source_path = "5B2_anaerobic_digestion"  # Changed from landfills
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -118,10 +118,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Category.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_carbides_emis.py
+++ b/gch4i/emis_processing/task_carbides_emis.py
@@ -1,10 +1,10 @@
 """
 Name:                  2B5 Carbide Emissions
-Date Last Modified:    2025-01-21
+Date Last Modified:    2025-08-21
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized carbides emissions data
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/2B5_carbide/State_Carbides_1990-2022.xlsx
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/2B5_carbide/State_Carbides_1990-2023.xlsx
 Output Files:          - {emi_data_dir_path}/carbides_emi.csv
 """
 
@@ -16,11 +16,11 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
-    V3_DATA_PATH,
+    V4_DATA_PATH,
 )
 from gch4i.utils import tg_to_kt
 
@@ -35,9 +35,9 @@ file. The parameters are used to create the pytask task for the emi.
 # gch4i_name to filter the data guide
 source_name = "2B5_carbide"
 # Data Guide Dictionary
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (gch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -46,9 +46,9 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path / source_name / data.file_name.iloc[0],
+        "input_path": v4_ghgi_data_dir_path / source_name / data.file_name.iloc[0],
         "source_list": data.gch4i_source.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 # %% Create Pytask Function and Loop
@@ -82,7 +82,7 @@ for _id, _kwargs in emi_parameters_dict.items():
             pd.read_excel(
                 input_path,
                 sheet_name="InvDB",
-                skiprows=15,
+                #skiprows=15,
                 # nrows=115,
                 # usecols="A:BA",
             )

--- a/gch4i/emis_processing/task_coal_surf_emi.py
+++ b/gch4i/emis_processing/task_coal_surf_emi.py
@@ -1,15 +1,15 @@
 """
 Name:                   task_coal_surf_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of coal emissions to State, Year, emissions format
 gch4i_name:             1B1a_coal_mining_surface
 Input Files:            - {ghgi_data_dir_path}/1B1a_coal_mining_surface/
-                            Coal_90-22_FRv1-InvDBcorrection.xlsx
+                            Coal_90-23_FRv1.xlsx
 Output Files:           - {emi_data_dir_path}/
                             coal_post_surf_emi.csv
                             coal_surf_emi.csv
-Notes:                  - V3 separates coal_mining_surface and coal_mining_underground
+Notes:                  - V4 separates coal_mining_surface and coal_mining_underground
 """
 # %% STEP 0. Load packages, configuration files, and local parameters ------------------
 from pathlib import Path
@@ -20,9 +20,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -57,8 +57,8 @@ def get_coal_surf_inv_data(in_path, src, params):
     emi_df = pd.read_excel(
         in_path,
         sheet_name=params["arguments"][0],  # sheet name
-        skiprows=params["arguments"][1],  # skip rows
-        nrows=params["arguments"][2],  # number of rows
+        #skiprows=params["arguments"][1],  # skip rows
+        #nrows=params["arguments"][2],  # number of rows
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -115,9 +115,9 @@ source_name = "1B1a_coal_mining_surface"
 source_path = "1B1a_coal_mining_surface"  # Changed from coal
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -126,10 +126,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_coal_under_emi.py
+++ b/gch4i/emis_processing/task_coal_under_emi.py
@@ -1,11 +1,11 @@
 """
 Name:                   task_coal_under_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of coal emissions to State, Year, emissions format
 gch4i_name:             1B1a_coal_mining_underground
 Input Files:            - {ghgi_data_dir_path}/1B1a_coal_mining_underground/
-                            Coal_90-22_FRv1-InvDBcorrection.xlsx
+                            Coal_90-23_FRv1.xlsx
 Output Files:           - {emi_data_dir_path}/
                             coal_post_under_emi.csv
                             coal_under_emi.csv
@@ -19,9 +19,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -54,8 +54,8 @@ def get_coal_under_inv_data(in_path, src, params):
     emi_df = pd.read_excel(
         in_path,
         sheet_name=params["arguments"][0],  # Sheet
-        skiprows=params["arguments"][1],  # Skip rows
-        nrows=params["arguments"][2],  # Number of rows
+        #skiprows=params["arguments"][1],  # Skip rows
+        #nrows=params["arguments"][2],  # Number of rows
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -112,9 +112,9 @@ source_name = "1B1a_coal_mining_underground"
 source_path = "1B1a_coal_mining_underground"  # Changed from coal
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -123,10 +123,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_composting_emi.py
+++ b/gch4i/emis_processing/task_composting_emi.py
@@ -3,9 +3,9 @@ Name:                  5B1 Composting Emissions
 Date Last Modified:    2025-01-22
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized composting emissions data
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/5B1_composting/State_Composting_1990-2021
-                        .xlsx
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/
+                            5B1_composting/State_Composting_1990-2023.xlsx
 Output Files:          - {emi_data_dir_path}/composting_emi.csv
 """
 
@@ -17,15 +17,13 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    tmp_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
-#from gch4i.utils import tg_to_kt
-tg_to_kt = 1000
+from gch4i.utils import tg_to_kt
 
 # %% Initialize Parameters
 """
@@ -38,9 +36,9 @@ file. The parameters are used to create the pytask task for the emi.
 # gch4i_name to filter the data guide
 source_name = "5B1_composting"
 # Data Guide Dictionary
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (gch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -49,9 +47,9 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path / source_name / data.file_name.iloc[0],
+        "input_path": v4_ghgi_data_dir_path / source_name / data.file_name.iloc[0],
         "source_list": data.gch4i_source.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 # %% Create Pytask Function and Loop
@@ -82,20 +80,19 @@ for _id, _kwargs in emi_parameters_dict.items():
             # read in the data
             pd.read_excel(
                 input_path,
-                sheet_name="InvDB",
-                skiprows=15
+                sheet_name="InvDB"
             )
             # name column names lower
             .rename(columns=lambda x: str(x).lower())
             # format the names of the emission source group strings
             .assign(
-                ghgi_source=lambda df: df["subsource"]
+                ghgi_source=lambda df: df["category"]
                 .astype(str)
                 .str.strip()
                 .str.casefold()
             )
             # rename the location column to what we need
-            .rename(columns={"state": "state_code"})
+            .rename(columns={"georef": "state_code"})
             # get just CH4 emissions, get only the emissions of our ghgi group
             .query("(ghg == 'CH4') & (ghgi_source.isin(@source_list))")
             # get just the columns we need

--- a/gch4i/emis_processing/task_dom_wastewater_emi.py
+++ b/gch4i/emis_processing/task_dom_wastewater_emi.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_dom_wastewater_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of domestic wastewater emissions to State, Year,
                         emissions format
 gch4i_name:             5D1_domestic_wastewater
 Input Files:            - {ghgi_data_dir_path}/5D1_domestic_wastewater/
-                            WW_State-level Estimates_90-22_27June2024.xlsx
+                            WW_State-level Estimates_90-23_ER_v1_8Apr2025_epa.xlsx
 Output Files:           - {emi_data_dir_path}/
                             ww_dom_nonseptic_emi.csv
                             ww_sep_emi.csv
@@ -21,9 +21,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (  # noqa
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
@@ -106,9 +106,9 @@ source_name = "5D1_domestic_wastewater"
 source_path = "5D1_domestic_wastewater"  # Changed from wastewater
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -117,10 +117,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_ferro_emi.py
+++ b/gch4i/emis_processing/task_ferro_emi.py
@@ -1,10 +1,10 @@
 """
 Name:                  2C2 Ferroalloy Emissions
-Date Last Modified:    2025-01-17
+Date Last Modified:    2025-08-21
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized abandoned ferroalloy emissions data
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/2C2_ferroalloy/State_Ferroalloys_1990-2022.
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/2C2_ferroalloy/State_Ferroalloys_1990-2023.
                         xlsx
 Output Files:          - {emi_data_dir_path}/ferro_emi.csv
 """
@@ -17,9 +17,9 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -46,7 +46,7 @@ def read_emi_data(in_path, src):
         pd.read_excel(
             in_path,
             sheet_name="InvDB",
-            skiprows=15,
+            #skiprows=15,
             # nrows=115,
             # usecols="A:BA",
         )
@@ -70,9 +70,10 @@ def read_emi_data(in_path, src):
         # set the index to state
         .set_index("state_code")
         # covert "NO" string to numeric (will become np.nan)
+        .replace(0, pd.NA)
         .apply(pd.to_numeric, errors="coerce")
-        # # drop states that have all nan values
         .dropna(how="all")
+        .fillna(0)
         # reset the index state back to a column
         .reset_index()
         # make the table long by state/year
@@ -106,9 +107,9 @@ file. The parameters are used to create the pytask task for the emi.
 # gch4i_name to filter the data guide
 source_name = "2C2_ferroalloy"
 # data guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # read and query for the source name (gch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -117,9 +118,9 @@ emi_parameters_dict = {}
 # loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [list(ghgi_data_dir_path.rglob(x))[0] for x in data.file_name],
+        "input_paths": [list(v4_ghgi_data_dir_path.rglob(x))[0] for x in data.file_name],
         "source_list": data.gch4i_source.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 # %% Create Pytask Function and Loop

--- a/gch4i/emis_processing/task_field_burning_emi.py
+++ b/gch4i/emis_processing/task_field_burning_emi.py
@@ -1,10 +1,11 @@
 """
 Name:                  3F4 Field Burning Emissions
-Date Last Modified:    2025-01-21
+Date Last Modified:    2025-08-21
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized field burning emissions data
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/3F4_fbar/FBAR_90-22_State.xlsx.
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/3F4_fbar/
+                        Field Burning of Ag Residues_1990-2023_State.xlsx
 Output Files:          - {emi_data_dir_path}/barley_emi.csv
                                             /chickpeas_emi.csv
                                             /cotton_emi.csv
@@ -38,9 +39,9 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -58,9 +59,9 @@ file. The parameters are used to create the pytask task for the emi.
 # gch4i_name to filter the data guide
 source_name = "3F4_fbar"
 # Data Guide Dictionary
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (gch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -69,10 +70,12 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path / source_name / data.file_name.iloc[0],
+        "input_path": v4_ghgi_data_dir_path / source_name / data.file_name.iloc[0],
         "source_list": data.gch4i_source.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
+
+emi_parameters_dict
 
 
 # %% Create Pytask Function and Loop
@@ -100,6 +103,7 @@ for _id, _kwargs in emi_parameters_dict.items():
 
         # Clean the source list
         source_list = [x.strip().casefold() for x in source_list]
+
         # Define years of interest
         year_list = [str(x) for x in list(range(min_year, max_year + 1))]
 
@@ -107,10 +111,7 @@ for _id, _kwargs in emi_parameters_dict.items():
             # read in the data
             pd.read_excel(
                 input_path,
-                sheet_name="InvDB",
-                skiprows=15,
-                # nrows=115,
-                # usecols="A:BA",
+                sheet_name="InvDB"
             )
             # name column names lower
             .rename(columns=lambda x: str(x).lower())
@@ -121,7 +122,6 @@ for _id, _kwargs in emi_parameters_dict.items():
                 .fillna(df["subcategory2"])
                 .replace("", np.nan)
                 .fillna(df["subcategory1"])
-                .str.replace(" ", "_")
                 .str.lower()
             )
             .dropna(subset="ghgi_source")

--- a/gch4i/emis_processing/task_flooded_lands_emi.py
+++ b/gch4i/emis_processing/task_flooded_lands_emi.py
@@ -1,14 +1,14 @@
 """
 Name:                   task_wetlands_rem_wet_emi.py
-Date Last Modified:     2025-06-13
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette, Nick Kruskamp (RTI International)
 Purpose:                Mapping of wetlands remaining wetlands emissions to State, Year,
                             emissions format
 gch4i_name:             4D1_wetlands_remaining_wetlands
 Input Files:            - {ghgi_data_dir_path}/4D1_wetlands_remaining_wetlands/
-                            FloodedLands_90-22_State.xlsx [InvDB]
-                            Peatlands_90-22_State_ERG_05.14.24.xlsx [InvDB]
-                            CoastalWetlands_90-22_FR.xlsx [InvDB]
+                            FloodedLands_Output_State.xlsx [InvDB]
+                            Peatlands_1990-2023_State.xlsx [InvDB]
+                            CoastalWetlands_90-23_FR.xlsx [InvDB]
 Emis/Output Files:      - {emi_data_dir_path}/
                             rem_flooded_land_reservoir_emi.csv
                             rem_flooded_land_other_emi.csv
@@ -25,9 +25,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
@@ -56,7 +56,6 @@ def get_wetlands_rem_wet_inv_data(in_path, params):
     emi_df = pd.read_excel(
         in_path,
         sheet_name=params["arguments"][0],  # Sheet name
-        skiprows=params["arguments"][1],  # Skip rows
     )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -139,9 +138,9 @@ file. The parameters are used to create the pytask task for the emi.
 source_name_1 = "4D1_wetlands_remaining_wetlands"
 source_name_2 = "4D2_land_converted_to_wetlands"
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"(gch4i_name == '{source_name_1}') | (gch4i_name == '{source_name_2}')"
 )
 
@@ -151,11 +150,11 @@ emi_parameters_dict = {}
 for emi_name, data in proxy_data.groupby("emi_id"):
     print(data)
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path
+        "input_path": v4_ghgi_data_dir_path
         / data.gch4i_name.values[0]
         / data.file_name.values[0],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_forest_land_emi.py
+++ b/gch4i/emis_processing/task_forest_land_emi.py
@@ -1,13 +1,13 @@
 """
 Name:                   task_forest_land_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-27
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of Forest Land emissions to State, Year, emissions
                         format
 gch4i_name:             4A1_4A2_Forest_land_remaining_forest_land
 Input Files:            - {ghgi_data_dir_path}/
                             4A1_4A2_Forest_land_remaining_forest_land/
-                            ForestCarbon_90-22_State_Gridding.xlsx
+                            ForestCarbon_N2OsoilsFires_1990-2023_State.xlsx
 Output Files:           - {emi_data_dir_path}/forest_land_emi.csv
 """
 # %% STEP 0. Load packages, configuration files, and local parameters ------------------
@@ -19,9 +19,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -49,8 +49,8 @@ def get_forest_land_inv_data(in_path, src, params):
     emi_df = pd.read_excel(
         in_path,
         sheet_name=params["arguments"][0],  # Sheet name
-        skiprows=params["arguments"][1],  # Skip rows
-        nrows=params["arguments"][2],  # Number of rows
+        # skiprows=params["arguments"][1],  # Skip rows
+        # nrows=params["arguments"][2],  # Number of rows
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -109,9 +109,9 @@ source_name = "4A1_4A2_Forest_land_remaining_forest_land"
 source_path = "4A1_4A2_Forest_land_remaining_forest_land"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -120,10 +120,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_grassland_emi.py
+++ b/gch4i/emis_processing/task_grassland_emi.py
@@ -1,11 +1,11 @@
 """
 Name:                   task_grassland_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of Grassland emissions to State, Year, emissions format
 gch4i_name:             4C1_4C2_Grassland_remaining_grassland
 Input Files:            - {ghgi_data_dir_path}/4C1_4C2_Grassland_remaining_grassland/
-                            GrassFires_nonCO2_90-22_FR.xlsx
+                            GrassFires_nonCO2_1990-2023_State.xlsx
 Output Files:           - {emi_data_dir_path}/
                             grassland_emi.csv
 """
@@ -18,9 +18,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -47,8 +47,6 @@ def get_grassland_inv_data(in_path, src, params):
     emi_df = pd.read_excel(
         in_path,
         sheet_name=params["arguments"][0],  # Sheet name
-        skiprows=params["arguments"][1],  # Skip rows
-        nrows=params["arguments"][2],  # Number of rows
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -105,9 +103,9 @@ source_name = "4C1_4C2_Grassland_remaining_grassland"
 source_path = "4C1_4C2_Grassland_remaining_grassland"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -116,10 +114,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_ind_wastewater_emi.py
+++ b/gch4i/emis_processing/task_ind_wastewater_emi.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_ind_wastewater_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-08-21
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of industrial wastewater emissions to State, Year,
                             emissions format
 gch4i_name:             5D2_industrial_wastewater
 Input Files:            - {ghgi_data_dir_path}/5D2_industrial_wastewater/
-                            WW_State-level Estimates_90-22_27June2024.xlsx
+                            WWW_State-level Estimates_90-23_ER_v1_8Apr2025_epa.xlsx
 Output Files:           - {emi_data_dir_path}/
                             ww_brew_emi.csv
                             ww_ethanol_emi.csv
@@ -25,9 +25,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -120,9 +120,9 @@ source_name = "5D2_industrial_wastewater"
 source_path = "5D2_industrial_wastewater"  # Changed from wastewater
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -131,10 +131,10 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_iron_steel_emi.py
+++ b/gch4i/emis_processing/task_iron_steel_emi.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_iron_steel_emi.py
-Date Last Modified:     2025-02-13
+Date Last Modified:     2025-08-21
 Authors Name:           Chris Coxen
 Purpose:                Mapping of iron and steel emissions to State, Year, emissions
                         format
 gch4i_name:             2C1_iron_and_steel
 Input Files:            - {ghgi_data_dir_path}/2C1_iron_and_steel/
-                            State_Iron-Steel_1990-2022.xlsx
+                            State_Iron-Steel_1990-2023.xlsx
 Output Files:           - {emi_data_dir_path}/
                             iron_steel_emi.csv
 """
@@ -19,9 +19,9 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     min_year,
     max_year
 )
@@ -52,9 +52,7 @@ def get_iron_and_steel_inv_data(in_path, src):
     emi_df = pd.read_excel(
         in_path,
         sheet_name="InvDB",
-        skiprows=15,
-        nrows=457,
-        usecols="A:BA"
+        #usecols="A:BC"
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -108,9 +106,9 @@ source_name = "2C1_iron_and_steel"
 source_path = "2C1_iron_and_steel"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -119,9 +117,9 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Category.to_list()],
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_mobile_comb_emi.py
+++ b/gch4i/emis_processing/task_mobile_comb_emi.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_mobile_comb_emi.py
-Date Last Modified:     2025-07-23
+Date Last Modified:     2025-08-27
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of mobile combustion emissions
 gch4i_name:             1A_mobile_combustion
 Input Files:            - {ghgi_data_dir_path}/1A_mobile_combustion/
-                            Mobile non-CO2 InvDB State Breakout_2022.xlsx
-                            Mobile Dataframe 11.24.2023_proxied_DC fixed.xlsx
+                            Mobile non-CO2 InvDB State Breakout_2023.xlsx
+                            SIT Mobile Dataframe_10.01.2024-Review.xlsx
 Output Files:           - {emi_data_dir_path}/
                             emi_passenger_cars.csv
                             emi_light.csv
@@ -39,9 +39,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -50,9 +50,9 @@ from gch4i.utils import tg_to_kt
 
 
 # Create function to grab the parameters from the excel file
-def read_excel_params(file_path, subsector, emission, sheet='emi_proxy_mapping'):
+def read_excel_params(file_path, subsector, emission, sheet='emi_data_guide'):
     """
-    Reads add_param column from gch4i_data_guide_v3.xlsx and returns a dictionary.
+    Reads add_param column from gch4i_data_guide_v4.xlsx and returns a dictionary.
     """
     # Read in Excel File
     df = (pd.read_excel(file_path, sheet_name=sheet)
@@ -109,7 +109,7 @@ def get_comb_mobile_inv_data(in_path, src, params):
                 'heavy-duty vehicles', 'diesel highway']):
         # Directly overwrite the params dictionary
         params = read_excel_params(proxy_file_path, source_name, src,
-                                   sheet='emi_proxy_mapping')
+                                   sheet='emi_data_guide')
     else:
         params = params
 
@@ -118,7 +118,6 @@ def get_comb_mobile_inv_data(in_path, src, params):
         pd.read_excel(
             in_path[0],
             sheet_name=params["arguments"][0],  # Sheet name
-            skiprows=params["arguments"][1],    # Skip rows
             index_col=None
         )
     )
@@ -175,7 +174,7 @@ def get_comb_mobile_inv_data(in_path, src, params):
     emi_df2 = (
         pd.read_excel(
             in_path[1],
-            sheet_name=params["arguments"][2],  # Sheet name
+            sheet_name=params["arguments"][1],  # Sheet name
             index_col=None
         )
     )
@@ -254,9 +253,9 @@ source_name = "1A_mobile_combustion"
 source_path = "1A_mobile_combustion"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -267,10 +266,10 @@ emi_parameters_dict = {}
 for emi_name, data in proxy_data.groupby("emi_id"):
     filenames = data.file_name.iloc[0].split(",")
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in filenames],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in filenames],
         "source_list": [x.strip().casefold() for x in data.Subcategory2.to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_petrochemicals_emis.py
+++ b/gch4i/emis_processing/task_petrochemicals_emis.py
@@ -1,12 +1,12 @@
 """
 Name:                   task_petrochemicals_emis.py
-Date Last Modified:     2024-12-16
+Date Last Modified:     2025-08-21
 Authors Name:           A. Burnette (RTI International)
 Purpose:                Mapping of petrochemicals emissions to State, Year, emissions
                         format
 gch4i_name:             2B8_petrochemicals
 Input Files:            - {ghgi_data_dir_path}/{2B8_petrochemicals}/
-                            State_Petrochemicals_1990-2022.xlsx
+                            State_Petrochemicals_1990-2023.xlsx
 Output Files:           - {emi_data_dir_path}/petrochemicals_emi.csv
 """
 # %% STEP 0. Load packages, configuration files, and local parameters ------------------
@@ -17,9 +17,9 @@ from pytask import Product, task, mark
 import pandas as pd
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
     )
@@ -46,9 +46,7 @@ def get_petrochemicals_inv_data(in_path, src):
     # Read in the data
     emi_df = pd.read_excel(
         in_path,
-        sheet_name="InvDB",
-        skiprows=15,
-        nrows=457,
+        sheet_name="InvDB"
         )
     # Specify years to keep
     year_list = [str(x) for x in list(range(min_year, max_year + 1))]
@@ -105,9 +103,9 @@ source_name = "2B8_petrochemicals"
 source_path = "2B8_petrochemicals"
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -116,9 +114,9 @@ emi_parameters_dict = {}
 # Loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in data.file_name],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in data.file_name],
         "source_list": [x.strip().casefold() for x in data.Subcategory1.to_list()],
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/emis_processing/task_rice_emi.py
+++ b/gch4i/emis_processing/task_rice_emi.py
@@ -1,10 +1,11 @@
 """
 Name:                  3C Rice Cultivation Emissions
-Date Last Modified:    2025-01-21
+Date Last Modified:    2025-08-21
 Authors Name:          Nick Kruskamp (RTI International)
 Purpose:               Clean and standardized rice cultivation emissions data
-Input Files:           - gch4i_data_guide_v3.xlsx
-                       - {V3_DATA_PATH}/ghgi/3C_rice_cultivation/Rice_90-22_State.xlsx
+Input Files:           - gch4i_data_guide_v4.xlsx
+                       - {V4_DATA_PATH}/ghgi/3C_rice_cultivation/
+                        Rice Cultivation_1990-2023_State.xlsx
 Output Files:          - {emi_data_dir_path}/rice_cult_emi.csv
 """
 
@@ -16,9 +17,9 @@ import pandas as pd
 from pytask import Product, mark, task
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year,
 )
@@ -36,9 +37,9 @@ file. The parameters are used to create the pytask task for the emi.
 # gch4i_name to filter the data guide
 source_name = "3C_rice_cultivation"
 # data guide directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # read and query for the source name (gch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -47,9 +48,9 @@ emi_parameters_dict = {}
 # loop through the proxy data and store the parameters in the emi_parameters_dict
 for emi_name, data in proxy_data.groupby("emi_id"):
     emi_parameters_dict[emi_name] = {
-        "input_path": ghgi_data_dir_path / source_name / data.file_name.iloc[0],
+        "input_path": v4_ghgi_data_dir_path / source_name / data.file_name.iloc[0],
         "source_list": data.gch4i_source.to_list(),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv",
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv",
     }
 
 input_path, source_list, output_path = emi_parameters_dict["rice_cult_emi"].values()
@@ -86,7 +87,7 @@ for _id, _kwargs in emi_parameters_dict.items():
             pd.read_excel(
                 input_path,
                 sheet_name="InvDB",
-                skiprows=15,
+                #skiprows=15,
                 # nrows=115,
                 # usecols="A:BA",
             )

--- a/gch4i/emis_processing/task_stat_comb_emi.py
+++ b/gch4i/emis_processing/task_stat_comb_emi.py
@@ -1,10 +1,10 @@
 """
 Name:                   task_stat_comb_emi.py
-Date Last Modified:     2025-01-30
+Date Last Modified:     2025-10-27
 Authors Name:           Andrew Burnette (RTI International)
 Purpose:                Mapping of stationary combustion emissions
 Input Files:            - {ghgi_data_dir_path}/1A_stationary_combustion/
-                            Stationary non-CO2 InvDB State Breakout_2022.xlsx
+                            Stationary non-CO2 InvDB State Breakout_2023.xlsx
 Output Files:           - {emi_data_dir_path}/
                             not_mapped_emi.csv
                             stat_comb_comm_emi.csv
@@ -26,9 +26,9 @@ import pandas as pd
 import ast
 
 from gch4i.config import (
-    V3_DATA_PATH,
-    emi_data_dir_path,
-    ghgi_data_dir_path,
+    V4_DATA_PATH,
+    v4_emi_data_dir_path,
+    v4_ghgi_data_dir_path,
     max_year,
     min_year
 )
@@ -58,7 +58,6 @@ def get_comb_stat_inv_data(in_path, src, params):
         pd.read_excel(
             in_path[0],
             sheet_name=params["arguments"][0],  # Sheet name
-            skiprows=params["arguments"][1],  # Skip rows
             index_col=None
         )
     )
@@ -82,6 +81,9 @@ def get_comb_stat_inv_data(in_path, src, params):
     # Query for Electricity Generation & speicific fuel type, if category
     if cat == "Electricity Generation":
         emi_df = emi_df.query('category == "Electricity Generation" and fuel1 == @fuel')
+    # Query for Residential & Biomass fuel type, if category
+    elif cat == "Residential" and fuel == "Biomass":
+        emi_df = emi_df.query('category == "Residential" and fuel1 == "Biomass"')
     # Query for identified category and fuel type
     else:
         emi_df = emi_df.query('category == @cat and fuel1 == @fuel')
@@ -127,9 +129,9 @@ source_name = "1A_stationary_combustion"
 source_path = "1A_stationary_combustion"  # Changed from combustion_stationary
 
 # Data Guide Directory
-proxy_file_path = V3_DATA_PATH.parents[1] / "gch4i_data_guide_v3.xlsx"
+proxy_file_path = V4_DATA_PATH.parents[0] / "gch4i_data_guide_v4.xlsx"
 # Read and query for the source name (ghch4i_name)
-proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_proxy_mapping").query(
+proxy_data = pd.read_excel(proxy_file_path, sheet_name="emi_data_guide").query(
     f"gch4i_name == '{source_name}'"
 )
 
@@ -140,11 +142,11 @@ emi_parameters_dict = {}
 for emi_name, data in proxy_data.groupby("emi_id"):
     filenames = data.file_name.iloc[0].split(",")
     emi_parameters_dict[emi_name] = {
-        "input_paths": [ghgi_data_dir_path / source_path / x for x in filenames],
+        "input_paths": [v4_ghgi_data_dir_path / source_path / x for x in filenames],
         "source_list": [x.strip().casefold() for x in (data.Category + "_" + data.Fuel1)
                         .to_list()],
         "parameters": ast.literal_eval(data.add_params.iloc[0]),
-        "output_path": emi_data_dir_path / f"{emi_name}.csv"
+        "output_path": v4_emi_data_dir_path / f"{emi_name}.csv"
     }
 
 emi_parameters_dict

--- a/gch4i/utils.py
+++ b/gch4i/utils.py
@@ -36,7 +36,9 @@ from pyproj import CRS
 
 from gch4i.config import (
     V3_DATA_PATH,
-    global_data_dir_path,
+    V4_DATA_PATH,
+    v4_global_data_dir_path,
+    #global_data_dir_path,
     load_road_globals,
     max_year,
     min_year,


### PR DESCRIPTION
There are 3 groups of files being updated:
1. config.py
2. utils.py
3. non-oil/gas emi files

**1. config.py**
The config file has been updated to include PROJECT_DIR_PATH from the .env. My .env is below:
PROJECT_DIR_PATH = "/Users/aburnette/Library/CloudStorage/OneDrive-SharedLibraries-EnvironmentalProtectionAgency(EPA)/Gridded CH4 Inventory - RTI 2024 Task Order/Task 2"
The updated config.py separates out V3 and V4 paths from the project_dir_path.

**2. utils.py**
The utils file was updated because emi files were failing, due to pulling tg_to_kt. Because utils.py was being imported from, utils was breaking because it pulls generic "global_data_path". I updated utils to include v4_paths and commented out global_data_dir_path for the moment. The long term fix would be to update functions in utils to use the correct path, or make the path an argument since there are now active V3 and V4 paths.

**3. Non-oil/gas emi files**
I updated all non-oil/gas emi files to include v4 paths, update to file dimensions for v4 (some InvDB and excel files changed formats), and ensured files write out to v4_emi dir correctly.